### PR TITLE
GPU fixes

### DIFF
--- a/crates/engine-cpu/benches/cpu_engine_bench.rs
+++ b/crates/engine-cpu/benches/cpu_engine_bench.rs
@@ -1,5 +1,5 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use engine_cpu::{FastCpuEngine, MinerEngine, Range};
+use engine_cpu::{AtomicBoolCancelCheck, FastCpuEngine, MinerEngine, Range};
 use pow_core::{hash_from_nonce, JobContext};
 use primitive_types::U512;
 use rand::RngCore;
@@ -9,6 +9,7 @@ fn bench_cpu_fast_engine(c: &mut Criterion) {
     // Create the engine
     let engine = FastCpuEngine::new();
     let cancel_flag = AtomicBool::new(false);
+    let cancel_check = AtomicBoolCancelCheck(&cancel_flag);
 
     let large_range = Range {
         start: U512::from(0u64),
@@ -25,7 +26,7 @@ fn bench_cpu_fast_engine(c: &mut Criterion) {
             let result = engine.search_range(
                 black_box(&ctx),
                 black_box(large_range.clone()),
-                black_box(&cancel_flag),
+                black_box(&cancel_check),
             );
             black_box(result)
         })

--- a/crates/engine-cpu/benches/cpu_engine_bench.rs
+++ b/crates/engine-cpu/benches/cpu_engine_bench.rs
@@ -6,8 +6,8 @@ use rand::RngCore;
 use std::sync::atomic::AtomicBool;
 
 fn bench_cpu_fast_engine(c: &mut Criterion) {
-    // Create the engine
-    let engine = FastCpuEngine::new();
+    // Create the engine with batch size of 10000
+    let engine = FastCpuEngine::new(10_000);
     let cancel_flag = AtomicBool::new(false);
     let cancel_check = AtomicBoolCancelCheck(&cancel_flag);
 

--- a/crates/engine-cpu/src/lib.rs
+++ b/crates/engine-cpu/src/lib.rs
@@ -147,12 +147,19 @@ impl MinerEngine for FastCpuEngine {
 
         let mut current = range.start;
         let mut hash_count: u64 = 0;
+        // Use decrementing counter to avoid modulo division in hot loop
+        // Initialize to 0 so we check cancellation immediately on first iteration
+        let mut until_check: u64 = 0;
 
         loop {
             // Check for cancellation every batch_size hashes
-            if hash_count.is_multiple_of(self.batch_size) && cancel.is_cancelled() {
-                return EngineStatus::Cancelled { hash_count };
+            if until_check == 0 {
+                if cancel.is_cancelled() {
+                    return EngineStatus::Cancelled { hash_count };
+                }
+                until_check = self.batch_size;
             }
+            until_check -= 1;
 
             let hash = hash_from_nonce(ctx, current);
             hash_count = hash_count.saturating_add(1);

--- a/crates/engine-cpu/src/lib.rs
+++ b/crates/engine-cpu/src/lib.rs
@@ -95,7 +95,12 @@ pub trait MinerEngine: Send + Sync {
     fn prepare_context(&self, header_hash: [u8; 32], difficulty: U512) -> JobContext;
 
     /// Search an inclusive nonce range with cancellation support.
-    fn search_range(&self, ctx: &JobContext, range: Range, cancel: &dyn CancelCheck) -> EngineStatus;
+    fn search_range(
+        &self,
+        ctx: &JobContext,
+        range: Range,
+        cancel: &dyn CancelCheck,
+    ) -> EngineStatus;
 
     /// Enable downcasting to concrete engine types.
     fn as_any(&self) -> &dyn std::any::Any;
@@ -128,7 +133,12 @@ impl MinerEngine for FastCpuEngine {
         self
     }
 
-    fn search_range(&self, ctx: &JobContext, range: Range, cancel: &dyn CancelCheck) -> EngineStatus {
+    fn search_range(
+        &self,
+        ctx: &JobContext,
+        range: Range,
+        cancel: &dyn CancelCheck,
+    ) -> EngineStatus {
         use pow_core::{hash_from_nonce, is_valid_hash, step_nonce};
 
         if range.start > range.end {

--- a/crates/engine-cpu/src/lib.rs
+++ b/crates/engine-cpu/src/lib.rs
@@ -8,7 +8,7 @@
 
 use pow_core::JobContext;
 use primitive_types::U512;
-use std::sync::atomic::{AtomicBool, Ordering as AtomicOrdering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
 /// An inclusive nonce range to search.
 #[derive(Clone, Debug)]
@@ -53,6 +53,36 @@ pub enum EngineStatus {
     },
 }
 
+/// Cancellation checker passed to search_range.
+/// Returns true if the search should be cancelled.
+pub trait CancelCheck: Send + Sync {
+    fn is_cancelled(&self) -> bool;
+}
+
+/// Simple cancel check using an AtomicBool flag.
+/// Useful for benchmarks and simple scenarios.
+pub struct AtomicBoolCancelCheck<'a>(pub &'a AtomicBool);
+
+impl CancelCheck for AtomicBoolCancelCheck<'_> {
+    fn is_cancelled(&self) -> bool {
+        self.0.load(Ordering::Relaxed)
+    }
+}
+
+/// Cancel check using job ID comparison.
+/// When a new job starts, the current_job_id is incremented.
+/// Workers compare their job_id against the current to detect cancellation.
+pub struct JobIdCancelCheck<'a> {
+    pub current_job_id: &'a AtomicU64,
+    pub my_job_id: u64,
+}
+
+impl CancelCheck for JobIdCancelCheck<'_> {
+    fn is_cancelled(&self) -> bool {
+        self.current_job_id.load(Ordering::Relaxed) != self.my_job_id
+    }
+}
+
 /// Abstract mining engine interface.
 ///
 /// The service layer depends only on this trait to manage jobs.
@@ -65,7 +95,7 @@ pub trait MinerEngine: Send + Sync {
     fn prepare_context(&self, header_hash: [u8; 32], difficulty: U512) -> JobContext;
 
     /// Search an inclusive nonce range with cancellation support.
-    fn search_range(&self, ctx: &JobContext, range: Range, cancel: &AtomicBool) -> EngineStatus;
+    fn search_range(&self, ctx: &JobContext, range: Range, cancel: &dyn CancelCheck) -> EngineStatus;
 
     /// Enable downcasting to concrete engine types.
     fn as_any(&self) -> &dyn std::any::Any;
@@ -94,7 +124,7 @@ impl MinerEngine for FastCpuEngine {
         self
     }
 
-    fn search_range(&self, ctx: &JobContext, range: Range, cancel: &AtomicBool) -> EngineStatus {
+    fn search_range(&self, ctx: &JobContext, range: Range, cancel: &dyn CancelCheck) -> EngineStatus {
         use pow_core::{hash_from_nonce, is_valid_hash, step_nonce};
 
         if range.start > range.end {
@@ -105,7 +135,7 @@ impl MinerEngine for FastCpuEngine {
         let mut hash_count: u64 = 0;
 
         loop {
-            if cancel.load(AtomicOrdering::Relaxed) {
+            if cancel.is_cancelled() {
                 return EngineStatus::Cancelled { hash_count };
             }
 
@@ -157,9 +187,10 @@ mod tests {
         };
 
         let cancel = AtomicBool::new(false);
+        let cancel_check = AtomicBoolCancelCheck(&cancel);
         let engine = FastCpuEngine::new();
 
-        let status = engine.search_range(&ctx, range.clone(), &cancel);
+        let status = engine.search_range(&ctx, range.clone(), &cancel_check);
         match status {
             EngineStatus::Exhausted { hash_count } => {
                 let expected = (range.end - range.start + U512::one()).as_u64();
@@ -181,9 +212,10 @@ mod tests {
         };
 
         let cancel = AtomicBool::new(true); // pre-cancelled
+        let cancel_check = AtomicBoolCancelCheck(&cancel);
         let engine = FastCpuEngine::new();
 
-        let status = engine.search_range(&ctx, range, &cancel);
+        let status = engine.search_range(&ctx, range, &cancel_check);
         match status {
             EngineStatus::Cancelled { hash_count } => {
                 assert_eq!(hash_count, 0);

--- a/crates/engine-cpu/src/lib.rs
+++ b/crates/engine-cpu/src/lib.rs
@@ -102,12 +102,16 @@ pub trait MinerEngine: Send + Sync {
 }
 
 /// Fast CPU engine using optimized pow-core helpers.
-#[derive(Default)]
-pub struct FastCpuEngine;
+pub struct FastCpuEngine {
+    /// How often to check for cancellation (in hashes)
+    batch_size: u64,
+}
 
 impl FastCpuEngine {
-    pub fn new() -> Self {
-        Self
+    pub fn new(batch_size: u64) -> Self {
+        Self {
+            batch_size: batch_size.max(1), // Ensure at least 1
+        }
     }
 }
 
@@ -135,7 +139,8 @@ impl MinerEngine for FastCpuEngine {
         let mut hash_count: u64 = 0;
 
         loop {
-            if cancel.is_cancelled() {
+            // Check for cancellation every batch_size hashes
+            if hash_count.is_multiple_of(self.batch_size) && cancel.is_cancelled() {
                 return EngineStatus::Cancelled { hash_count };
             }
 
@@ -188,7 +193,7 @@ mod tests {
 
         let cancel = AtomicBool::new(false);
         let cancel_check = AtomicBoolCancelCheck(&cancel);
-        let engine = FastCpuEngine::new();
+        let engine = FastCpuEngine::new(1000); // check every 1000 hashes
 
         let status = engine.search_range(&ctx, range.clone(), &cancel_check);
         match status {
@@ -213,7 +218,7 @@ mod tests {
 
         let cancel = AtomicBool::new(true); // pre-cancelled
         let cancel_check = AtomicBoolCancelCheck(&cancel);
-        let engine = FastCpuEngine::new();
+        let engine = FastCpuEngine::new(1); // check every hash for immediate cancellation
 
         let status = engine.search_range(&ctx, range, &cancel_check);
         match status {

--- a/crates/engine-gpu/benches/gpu_engine_bench.rs
+++ b/crates/engine-gpu/benches/gpu_engine_bench.rs
@@ -7,8 +7,8 @@ use rand::RngCore;
 use std::sync::atomic::AtomicBool;
 
 fn bench_cpu_vs_gpu_small(c: &mut Criterion) {
-    let cpu_engine = FastCpuEngine::new();
-    let gpu_engine = GpuEngine::new();
+    let cpu_engine = FastCpuEngine::new(10_000);
+    let gpu_engine = GpuEngine::try_new(10_000_000).expect("Failed to init GPU");
     let cancel_flag = AtomicBool::new(false);
     let cancel_check = AtomicBoolCancelCheck(&cancel_flag);
 
@@ -58,8 +58,8 @@ fn bench_cpu_vs_gpu_small(c: &mut Criterion) {
 }
 
 fn bench_cpu_vs_gpu_medium(c: &mut Criterion) {
-    let cpu_engine = FastCpuEngine::new();
-    let gpu_engine = GpuEngine::new();
+    let cpu_engine = FastCpuEngine::new(10_000);
+    let gpu_engine = GpuEngine::try_new(10_000_000).expect("Failed to init GPU");
     let cancel_flag = AtomicBool::new(false);
     let cancel_check = AtomicBoolCancelCheck(&cancel_flag);
 
@@ -109,8 +109,8 @@ fn bench_cpu_vs_gpu_medium(c: &mut Criterion) {
 }
 
 fn bench_cpu_vs_gpu_large(c: &mut Criterion) {
-    let cpu_engine = FastCpuEngine::new();
-    let gpu_engine = GpuEngine::new();
+    let cpu_engine = FastCpuEngine::new(10_000);
+    let gpu_engine = GpuEngine::try_new(10_000_000).expect("Failed to init GPU");
     let cancel_flag = AtomicBool::new(false);
     let cancel_check = AtomicBoolCancelCheck(&cancel_flag);
 
@@ -160,8 +160,8 @@ fn bench_cpu_vs_gpu_large(c: &mut Criterion) {
 }
 
 fn bench_solution_finding(c: &mut Criterion) {
-    let cpu_engine = FastCpuEngine::new();
-    let gpu_engine = GpuEngine::new();
+    let cpu_engine = FastCpuEngine::new(10_000);
+    let gpu_engine = GpuEngine::try_new(10_000_000).expect("Failed to init GPU");
     let cancel_flag = AtomicBool::new(false);
     let cancel_check = AtomicBoolCancelCheck(&cancel_flag);
 
@@ -211,8 +211,8 @@ fn bench_solution_finding(c: &mut Criterion) {
 }
 
 fn bench_throughput_per_second(c: &mut Criterion) {
-    let cpu_engine = FastCpuEngine::new();
-    let gpu_engine = GpuEngine::new();
+    let cpu_engine = FastCpuEngine::new(10_000);
+    let gpu_engine = GpuEngine::try_new(10_000_000).expect("Failed to init GPU");
     let cancel_flag = AtomicBool::new(false);
     let cancel_check = AtomicBoolCancelCheck(&cancel_flag);
 
@@ -262,7 +262,7 @@ fn bench_throughput_per_second(c: &mut Criterion) {
 }
 
 fn bench_gpu_batch_efficiency(c: &mut Criterion) {
-    let gpu_engine = GpuEngine::new();
+    let gpu_engine = GpuEngine::try_new(10_000_000).expect("Failed to init GPU");
     let cancel_flag = AtomicBool::new(false);
     let cancel_check = AtomicBoolCancelCheck(&cancel_flag);
 

--- a/crates/engine-gpu/benches/gpu_engine_bench.rs
+++ b/crates/engine-gpu/benches/gpu_engine_bench.rs
@@ -1,5 +1,5 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use engine_cpu::{FastCpuEngine, MinerEngine, Range};
+use engine_cpu::{AtomicBoolCancelCheck, FastCpuEngine, MinerEngine, Range};
 use engine_gpu::GpuEngine;
 use pow_core::JobContext;
 use primitive_types::U512;
@@ -10,6 +10,7 @@ fn bench_cpu_vs_gpu_small(c: &mut Criterion) {
     let cpu_engine = FastCpuEngine::new();
     let gpu_engine = GpuEngine::new();
     let cancel_flag = AtomicBool::new(false);
+    let cancel_check = AtomicBoolCancelCheck(&cancel_flag);
 
     // Small range: 10K nonces - reasonable for benchmarking
     let small_range = Range {
@@ -31,7 +32,7 @@ fn bench_cpu_vs_gpu_small(c: &mut Criterion) {
             let result = cpu_engine.search_range(
                 black_box(&ctx),
                 black_box(small_range.clone()),
-                black_box(&cancel_flag),
+                black_box(&cancel_check),
             );
             black_box(result)
         })
@@ -47,7 +48,7 @@ fn bench_cpu_vs_gpu_small(c: &mut Criterion) {
             let result = gpu_engine.search_range(
                 black_box(&ctx),
                 black_box(small_range.clone()),
-                black_box(&cancel_flag),
+                black_box(&cancel_check),
             );
             black_box(result)
         })
@@ -60,6 +61,7 @@ fn bench_cpu_vs_gpu_medium(c: &mut Criterion) {
     let cpu_engine = FastCpuEngine::new();
     let gpu_engine = GpuEngine::new();
     let cancel_flag = AtomicBool::new(false);
+    let cancel_check = AtomicBoolCancelCheck(&cancel_flag);
 
     // Medium range: 100K nonces
     let medium_range = Range {
@@ -81,7 +83,7 @@ fn bench_cpu_vs_gpu_medium(c: &mut Criterion) {
             let result = cpu_engine.search_range(
                 black_box(&ctx),
                 black_box(medium_range.clone()),
-                black_box(&cancel_flag),
+                black_box(&cancel_check),
             );
             black_box(result)
         })
@@ -97,7 +99,7 @@ fn bench_cpu_vs_gpu_medium(c: &mut Criterion) {
             let result = gpu_engine.search_range(
                 black_box(&ctx),
                 black_box(medium_range.clone()),
-                black_box(&cancel_flag),
+                black_box(&cancel_check),
             );
             black_box(result)
         })
@@ -110,6 +112,7 @@ fn bench_cpu_vs_gpu_large(c: &mut Criterion) {
     let cpu_engine = FastCpuEngine::new();
     let gpu_engine = GpuEngine::new();
     let cancel_flag = AtomicBool::new(false);
+    let cancel_check = AtomicBoolCancelCheck(&cancel_flag);
 
     // Large range: 1M nonces - where GPU should really shine
     let large_range = Range {
@@ -131,7 +134,7 @@ fn bench_cpu_vs_gpu_large(c: &mut Criterion) {
             let result = cpu_engine.search_range(
                 black_box(&ctx),
                 black_box(large_range.clone()),
-                black_box(&cancel_flag),
+                black_box(&cancel_check),
             );
             black_box(result)
         })
@@ -147,7 +150,7 @@ fn bench_cpu_vs_gpu_large(c: &mut Criterion) {
             let result = gpu_engine.search_range(
                 black_box(&ctx),
                 black_box(large_range.clone()),
-                black_box(&cancel_flag),
+                black_box(&cancel_check),
             );
             black_box(result)
         })
@@ -160,6 +163,7 @@ fn bench_solution_finding(c: &mut Criterion) {
     let cpu_engine = FastCpuEngine::new();
     let gpu_engine = GpuEngine::new();
     let cancel_flag = AtomicBool::new(false);
+    let cancel_check = AtomicBoolCancelCheck(&cancel_flag);
 
     // Range where we expect to find solutions quickly
     let solution_range = Range {
@@ -181,7 +185,7 @@ fn bench_solution_finding(c: &mut Criterion) {
             let result = cpu_engine.search_range(
                 black_box(&ctx),
                 black_box(solution_range.clone()),
-                black_box(&cancel_flag),
+                black_box(&cancel_check),
             );
             black_box(result)
         })
@@ -197,7 +201,7 @@ fn bench_solution_finding(c: &mut Criterion) {
             let result = gpu_engine.search_range(
                 black_box(&ctx),
                 black_box(solution_range.clone()),
-                black_box(&cancel_flag),
+                black_box(&cancel_check),
             );
             black_box(result)
         })
@@ -210,6 +214,7 @@ fn bench_throughput_per_second(c: &mut Criterion) {
     let cpu_engine = FastCpuEngine::new();
     let gpu_engine = GpuEngine::new();
     let cancel_flag = AtomicBool::new(false);
+    let cancel_check = AtomicBoolCancelCheck(&cancel_flag);
 
     // Fixed time benchmark - see how many hashes we can do in 1 second
     let throughput_range = Range {
@@ -231,7 +236,7 @@ fn bench_throughput_per_second(c: &mut Criterion) {
             let result = cpu_engine.search_range(
                 black_box(&ctx),
                 black_box(throughput_range.clone()),
-                black_box(&cancel_flag),
+                black_box(&cancel_check),
             );
             black_box(result)
         })
@@ -247,7 +252,7 @@ fn bench_throughput_per_second(c: &mut Criterion) {
             let result = gpu_engine.search_range(
                 black_box(&ctx),
                 black_box(throughput_range.clone()),
-                black_box(&cancel_flag),
+                black_box(&cancel_check),
             );
             black_box(result)
         })
@@ -259,6 +264,7 @@ fn bench_throughput_per_second(c: &mut Criterion) {
 fn bench_gpu_batch_efficiency(c: &mut Criterion) {
     let gpu_engine = GpuEngine::new();
     let cancel_flag = AtomicBool::new(false);
+    let cancel_check = AtomicBoolCancelCheck(&cancel_flag);
 
     let mut group = c.benchmark_group("gpu_batch_sizes");
     group.sample_size(10);
@@ -290,7 +296,7 @@ fn bench_gpu_batch_efficiency(c: &mut Criterion) {
             let result = gpu_engine.search_range(
                 black_box(&ctx),
                 black_box(small_batch.clone()),
-                black_box(&cancel_flag),
+                black_box(&cancel_check),
             );
             black_box(result)
         })
@@ -306,7 +312,7 @@ fn bench_gpu_batch_efficiency(c: &mut Criterion) {
             let result = gpu_engine.search_range(
                 black_box(&ctx),
                 black_box(medium_batch.clone()),
-                black_box(&cancel_flag),
+                black_box(&cancel_check),
             );
             black_box(result)
         })
@@ -322,7 +328,7 @@ fn bench_gpu_batch_efficiency(c: &mut Criterion) {
             let result = gpu_engine.search_range(
                 black_box(&ctx),
                 black_box(large_batch.clone()),
-                black_box(&cancel_flag),
+                black_box(&cancel_check),
             );
             black_box(result)
         })

--- a/crates/engine-gpu/examples/verify_nonce.rs
+++ b/crates/engine-gpu/examples/verify_nonce.rs
@@ -1,4 +1,4 @@
-use engine_cpu::{EngineStatus, FastCpuEngine, MinerEngine, Range};
+use engine_cpu::{AtomicBoolCancelCheck, EngineStatus, FastCpuEngine, MinerEngine, Range};
 use engine_gpu::GpuEngine;
 use primitive_types::U512;
 use std::sync::atomic::AtomicBool;
@@ -22,6 +22,7 @@ fn main() {
     log::info!("Context prepared. Difficulty: {}", difficulty);
 
     let cancel = AtomicBool::new(false);
+    let cancel_check = AtomicBoolCancelCheck(&cancel);
 
     // 3. Verify with GPU engine
     log::info!("Initializing GPU engine...");
@@ -39,7 +40,7 @@ fn main() {
         gpu_range.end
     );
     let start = std::time::Instant::now();
-    let gpu_result = gpu_engine.search_range(&ctx, gpu_range, &cancel);
+    let gpu_result = gpu_engine.search_range(&ctx, gpu_range, &cancel_check);
     let elapsed = start.elapsed();
 
     log::info!("GPU search took {:?}", elapsed);

--- a/crates/engine-gpu/examples/verify_nonce.rs
+++ b/crates/engine-gpu/examples/verify_nonce.rs
@@ -16,7 +16,7 @@ fn main() {
     // Use a fixed header and easy difficulty (1) so any nonce is valid
     let header = [1u8; 32];
     let difficulty = U512::from(u64::MAX); // High difficulty - no solutions expected
-    let cpu_engine = FastCpuEngine::new();
+    let cpu_engine = FastCpuEngine::new(10_000);
     let ctx = cpu_engine.prepare_context(header, difficulty);
 
     log::info!("Context prepared. Difficulty: {}", difficulty);
@@ -26,7 +26,7 @@ fn main() {
 
     // 3. Verify with GPU engine
     log::info!("Initializing GPU engine...");
-    let gpu_engine = GpuEngine::new();
+    let gpu_engine = GpuEngine::try_new(10_000_000).expect("Failed to init GPU");
 
     // Search a small range around the valid nonce
     let gpu_range = Range {

--- a/crates/engine-gpu/src/lib.rs
+++ b/crates/engine-gpu/src/lib.rs
@@ -1,18 +1,19 @@
 #![deny(rust_2018_idioms)]
 #![forbid(unsafe_code)]
 
-use engine_cpu::{Candidate, EngineStatus, FoundOrigin, MinerEngine, Range};
+use engine_cpu::{CancelCheck, Candidate, EngineStatus, FoundOrigin, MinerEngine, Range};
 use futures::executor::block_on;
 use pow_core::{format_hashrate, format_u512, JobContext};
 use primitive_types::U512;
 use std::cell::RefCell;
 use std::sync::{
-    atomic::{AtomicBool, AtomicUsize, Ordering},
+    atomic::{AtomicUsize, Ordering},
     Arc,
 };
 
-/// Default interval for checking cancel flag in shader (in nonces)
-const DEFAULT_CANCEL_CHECK_INTERVAL: u32 = 100_000;
+/// Default batch size for GPU processing (in nonces)
+/// 10 million nonces per batch = ~50-500ms per batch depending on GPU
+const DEFAULT_BATCH_SIZE: u64 = 10_000_000;
 
 /// Represents a single GPU device context.
 struct GpuContext {
@@ -31,7 +32,6 @@ struct GpuResources {
     start_nonce_buffer: wgpu::Buffer,
     results_buffer: wgpu::Buffer,
     dispatch_config_buffer: wgpu::Buffer,
-    cancel_buffer: wgpu::Buffer,
     staging_buffer: wgpu::Buffer,
     bind_group: wgpu::BindGroup,
 }
@@ -39,7 +39,7 @@ struct GpuResources {
 pub struct GpuEngine {
     contexts: Vec<Arc<GpuContext>>,
     device_counter: AtomicUsize,
-    cancel_check_interval: u32,
+    batch_size: u64,
 }
 
 // Thread-local storage for consistent GPU device assignment per worker thread
@@ -87,18 +87,10 @@ impl GpuContext {
             mapped_at_creation: false,
         });
 
-        // Dispatch config: [total_threads, nonces_per_thread, total_nonces, cancel_check_interval] = 4 u32s
+        // Dispatch config: [total_threads, nonces_per_thread, total_nonces] = 3 u32s
         let dispatch_config_buffer = self.device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("Dispatch Config Buffer"),
-            size: 16,
-            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
-            mapped_at_creation: false,
-        });
-
-        // Cancel flag: single u32 (0 = running, 1 = cancel requested)
-        let cancel_buffer = self.device.create_buffer(&wgpu::BufferDescriptor {
-            label: Some("Cancel Buffer"),
-            size: 4,
+            size: 12,
             usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
             mapped_at_creation: false,
         });
@@ -134,10 +126,6 @@ impl GpuContext {
                     binding: 4,
                     resource: dispatch_config_buffer.as_entire_binding(),
                 },
-                wgpu::BindGroupEntry {
-                    binding: 5,
-                    resource: cancel_buffer.as_entire_binding(),
-                },
             ],
         });
 
@@ -147,7 +135,6 @@ impl GpuContext {
             start_nonce_buffer,
             results_buffer,
             dispatch_config_buffer,
-            cancel_buffer,
             staging_buffer,
             bind_group,
         }
@@ -162,29 +149,24 @@ impl Default for GpuEngine {
 
 impl GpuEngine {
     pub fn new() -> Self {
-        block_on(Self::init(DEFAULT_CANCEL_CHECK_INTERVAL))
+        block_on(Self::init(DEFAULT_BATCH_SIZE))
             .expect("Failed to initialize GPU engine")
-    }
-
-    /// Create a new GPU engine with a custom cancel check interval.
-    pub fn with_cancel_interval(cancel_check_interval: u32) -> Self {
-        block_on(Self::init(cancel_check_interval)).expect("Failed to initialize GPU engine")
     }
 
     /// Try to initialize the GPU engine, returning an error if initialization fails.
     pub fn try_new() -> Result<Self, Box<dyn std::error::Error>> {
-        block_on(Self::init(DEFAULT_CANCEL_CHECK_INTERVAL))
+        block_on(Self::init(DEFAULT_BATCH_SIZE))
     }
 
-    /// Try to initialize the GPU engine with a custom cancel check interval.
-    pub fn try_with_cancel_interval(
-        cancel_check_interval: u32,
+    /// Try to initialize the GPU engine with custom batch size.
+    pub fn try_with_batch_size(
+        batch_size: Option<u64>,
     ) -> Result<Self, Box<dyn std::error::Error>> {
-        block_on(Self::init(cancel_check_interval))
+        block_on(Self::init(batch_size.unwrap_or(DEFAULT_BATCH_SIZE)))
     }
 
-    async fn init(cancel_check_interval: u32) -> Result<Self, Box<dyn std::error::Error>> {
-        log::info!("Initializing WGPU...");
+    async fn init(batch_size: u64) -> Result<Self, Box<dyn std::error::Error>> {
+        log::info!(target: "gpu_engine", "Initializing WGPU...");
         let instance = wgpu::Instance::new(&wgpu::InstanceDescriptor {
             backends: wgpu::Backends::PRIMARY,
             ..Default::default()
@@ -196,7 +178,7 @@ impl GpuEngine {
         let adapters: Vec<_> = adapters.into_iter().collect();
 
         if adapters.is_empty() {
-            log::error!("No suitable GPU adapters found.");
+            log::error!(target: "gpu_engine", "No suitable GPU adapters found.");
             return Err("No suitable GPU adapters found".into());
         }
 
@@ -257,15 +239,16 @@ impl GpuEngine {
         }
 
         log::info!(
-            "GPU engine initialized with {} devices (cancel check interval: {} nonces)",
+            target: "gpu_engine",
+            "GPU engine initialized with {} devices (batch size: {} nonces)",
             contexts.len(),
-            cancel_check_interval
+            batch_size
         );
 
         Ok(Self {
             contexts,
             device_counter: AtomicUsize::new(0),
-            cancel_check_interval,
+            batch_size,
         })
     }
 
@@ -296,9 +279,9 @@ impl MinerEngine for GpuEngine {
         self
     }
 
-    fn search_range(&self, ctx: &JobContext, range: Range, cancel: &AtomicBool) -> EngineStatus {
+    fn search_range(&self, ctx: &JobContext, range: Range, cancel: &dyn CancelCheck) -> EngineStatus {
         if self.contexts.is_empty() {
-            log::warn!("No GPUs available for search.");
+            log::warn!(target: "gpu_engine", "No GPUs available for search.");
             return EngineStatus::Exhausted { hash_count: 0 };
         }
 
@@ -308,7 +291,7 @@ impl MinerEngine for GpuEngine {
         }
 
         // Check for pre-cancellation
-        if cancel.load(Ordering::Relaxed) {
+        if cancel.is_cancelled() {
             return EngineStatus::Cancelled { hash_count: 0 };
         }
 
@@ -325,6 +308,7 @@ impl MinerEngine for GpuEngine {
                 };
                 *assigned_ref = Some(index);
                 log::info!(
+                    target: "gpu_engine",
                     "Worker thread assigned to GPU device {} (of {} total devices)",
                     index,
                     self.contexts.len()
@@ -334,27 +318,6 @@ impl MinerEngine for GpuEngine {
         });
 
         let gpu_ctx = &self.contexts[device_index];
-
-        // Calculate range size (capped at u32::MAX for dispatch config)
-        let range_size_u512 = range
-            .end
-            .saturating_sub(range.start)
-            .saturating_add(U512::one());
-        let range_size = if range_size_u512 > U512::from(u32::MAX) {
-            u32::MAX as u64
-        } else {
-            range_size_u512.as_u64()
-        };
-
-        log::info!(
-            target: "gpu_engine",
-            "GPU {} search started: range {}..{}, nonces: {}, cancel check interval: {}",
-            device_index,
-            format_u512(range.start),
-            format_u512(range.end),
-            range_size,
-            self.cancel_check_interval
-        );
 
         // Ensure resources are initialized for this thread
         WORKER_RESOURCES.with(|resources_cell| {
@@ -367,7 +330,7 @@ impl MinerEngine for GpuEngine {
         let resources = WORKER_RESOURCES
             .with(|resources_cell| resources_cell.borrow().as_ref().unwrap().clone());
 
-        // Pre-convert header and target
+        // Pre-convert header and target (only needs to be done once per job)
         let mut header_u32s = [0u32; 8];
         for (i, item) in header_u32s.iter_mut().enumerate() {
             let chunk = &ctx.header[i * 4..(i + 1) * 4];
@@ -391,7 +354,139 @@ impl MinerEngine for GpuEngine {
             bytemuck::cast_slice(&target_u32s),
         );
 
-        // Calculate dispatch configuration
+        let search_start = std::time::Instant::now();
+        let mut total_hashes: u64 = 0;
+        let mut current_start = range.start;
+        let mut batch_num = 0u64;
+
+        log::info!(
+            target: "gpu_engine",
+            "GPU {} search started: range {}..{}, batch size: {} nonces",
+            device_index,
+            format_u512(range.start),
+            format_u512(range.end),
+            self.batch_size
+        );
+
+        // Process in batches, checking for cancellation between each batch
+        while current_start <= range.end {
+            // Check for cancellation at host level BEFORE starting each batch
+            if cancel.is_cancelled() {
+                let elapsed = search_start.elapsed();
+                log::info!(
+                    target: "gpu_engine",
+                    "GPU {} cancelled before batch {} ({} total hashes in {:.2}s)",
+                    device_index,
+                    batch_num,
+                    total_hashes,
+                    elapsed.as_secs_f64()
+                );
+                return EngineStatus::Cancelled {
+                    hash_count: total_hashes,
+                };
+            }
+
+            // Calculate batch range
+            let remaining = range.end.saturating_sub(current_start).saturating_add(U512::one());
+            let batch_size_u512 = U512::from(self.batch_size);
+            let this_batch_size = if remaining > batch_size_u512 {
+                self.batch_size
+            } else {
+                remaining.as_u64()
+            };
+
+            // Run single batch
+            let batch_result = self.run_single_batch(
+                gpu_ctx,
+                &resources,
+                current_start,
+                this_batch_size,
+            );
+
+            match batch_result {
+                BatchResult::Found { candidate, hash_count } => {
+                    total_hashes += hash_count;
+                    let elapsed = search_start.elapsed();
+                    let hash_rate = total_hashes as f64 / elapsed.as_secs_f64();
+
+                    log::debug!(
+                        target: "gpu_engine",
+                        "GPU {} found solution in batch {}! Nonce: {}, Hash: {} ({} total hashes in {:.2}s, {})",
+                        device_index,
+                        batch_num,
+                        format_u512(candidate.nonce),
+                        format_u512(candidate.hash),
+                        total_hashes,
+                        elapsed.as_secs_f64(),
+                        format_hashrate(hash_rate)
+                    );
+
+                    return EngineStatus::Found {
+                        candidate,
+                        hash_count: total_hashes,
+                        origin: FoundOrigin::GpuG1,
+                    };
+                }
+                BatchResult::NotFound { hash_count } => {
+                    total_hashes += hash_count;
+                }
+            }
+
+            // Move to next batch
+            current_start = current_start.saturating_add(U512::from(this_batch_size));
+            batch_num += 1;
+
+            // Log progress periodically (every 10 batches)
+            if batch_num.is_multiple_of(10) {
+                let elapsed = search_start.elapsed();
+                let hash_rate = total_hashes as f64 / elapsed.as_secs_f64();
+                log::debug!(
+                    target: "gpu_engine",
+                    "GPU {} batch {} complete: {} hashes so far ({:.2}s, {})",
+                    device_index,
+                    batch_num,
+                    total_hashes,
+                    elapsed.as_secs_f64(),
+                    format_hashrate(hash_rate)
+                );
+            }
+        }
+
+        // Range exhausted without finding solution
+        let elapsed = search_start.elapsed();
+        let hash_rate = total_hashes as f64 / elapsed.as_secs_f64();
+        log::info!(
+            target: "gpu_engine",
+            "GPU {} search exhausted: {} hashes in {} batches ({:.2}s, {})",
+            device_index,
+            total_hashes,
+            batch_num,
+            elapsed.as_secs_f64(),
+            format_hashrate(hash_rate)
+        );
+
+        EngineStatus::Exhausted {
+            hash_count: total_hashes,
+        }
+    }
+}
+
+/// Result from a single GPU batch
+enum BatchResult {
+    Found { candidate: Candidate, hash_count: u64 },
+    NotFound { hash_count: u64 },
+}
+
+impl GpuEngine {
+    /// Run a single batch of GPU computation
+    fn run_single_batch(
+        &self,
+        gpu_ctx: &GpuContext,
+        resources: &GpuResources,
+        batch_start: U512,
+        batch_size: u64,
+    ) -> BatchResult {
+        // Calculate dispatch configuration for this batch
         let threads_per_workgroup = 256u32;
         let limits = gpu_ctx.device.limits();
         let max_workgroups = limits.max_compute_workgroups_per_dimension;
@@ -399,26 +494,16 @@ impl MinerEngine for GpuEngine {
         let hinted_workgroups = gpu_ctx.optimal_workgroups.max(1).min(max_workgroups);
         let hinted_threads = hinted_workgroups as u64 * threads_per_workgroup as u64;
 
-        let logical_threads = range_size.min(hinted_threads).max(1);
+        let logical_threads = batch_size.min(hinted_threads).max(1);
         let num_workgroups = ((logical_threads as u32).div_ceil(threads_per_workgroup)).max(1);
         let total_threads = (num_workgroups * threads_per_workgroup) as u64;
-        let nonces_per_thread = (range_size.div_ceil(total_threads)).max(1) as u32;
+        let nonces_per_thread = (batch_size.div_ceil(total_threads)).max(1) as u32;
 
-        log::debug!(
-            target: "gpu_engine",
-            "GPU {} dispatch config: {} workgroups × {} threads, {} nonces/thread",
-            device_index,
-            num_workgroups,
-            threads_per_workgroup,
-            nonces_per_thread
-        );
-
-        // Dispatch config: [total_threads, nonces_per_thread, total_nonces, cancel_check_interval]
+        // Dispatch config: [total_threads, nonces_per_thread, total_nonces]
         let dispatch_config = [
             total_threads as u32,
             nonces_per_thread,
-            range_size as u32,
-            self.cancel_check_interval,
+            batch_size as u32,
         ];
 
         // Write dispatch config
@@ -428,8 +513,8 @@ impl MinerEngine for GpuEngine {
             bytemuck::cast_slice(&dispatch_config),
         );
 
-        // Write start nonce
-        let start_nonce_bytes = range.start.to_little_endian();
+        // Write start nonce for this batch
+        let start_nonce_bytes = batch_start.to_little_endian();
         gpu_ctx
             .queue
             .write_buffer(&resources.start_nonce_buffer, 0, &start_nonce_bytes);
@@ -440,13 +525,6 @@ impl MinerEngine for GpuEngine {
         gpu_ctx
             .queue
             .write_buffer(&resources.results_buffer, 0, &ZEROS);
-
-        // Reset cancel buffer to 0 (not cancelled)
-        gpu_ctx
-            .queue
-            .write_buffer(&resources.cancel_buffer, 0, &[0u8; 4]);
-
-        let search_start = std::time::Instant::now();
 
         // Create and submit command buffer
         let mut encoder = gpu_ctx
@@ -471,8 +549,7 @@ impl MinerEngine for GpuEngine {
 
         gpu_ctx.queue.submit(Some(encoder.finish()));
 
-        // Poll GPU with periodic cancel checks
-        // We use a shared flag to know when the mapping is complete
+        // Wait for GPU to complete (blocking)
         let buffer_slice = resources.staging_buffer.slice(..);
         let mapped = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
         let mapped_clone = mapped.clone();
@@ -482,39 +559,24 @@ impl MinerEngine for GpuEngine {
             }
         });
 
+        // Poll until complete
         loop {
-            // Check if cancelled
-            if cancel.load(Ordering::Relaxed) {
-                // Write cancel flag to GPU buffer
-                gpu_ctx
-                    .queue
-                    .write_buffer(&resources.cancel_buffer, 0, &1u32.to_le_bytes());
-                log::debug!(target: "gpu_engine", "GPU {} cancel flag propagated to GPU buffer", device_index);
-            }
-
-            // Poll with short timeout
             let _ = gpu_ctx.device.poll(wgpu::PollType::Wait {
                 submission_index: None,
                 timeout: Some(std::time::Duration::from_millis(10)),
             });
 
-            // Check if buffer mapping is complete
             if mapped.load(Ordering::Acquire) {
                 break;
             }
         }
 
-        let search_elapsed = search_start.elapsed();
-
         // Read results
         let data = buffer_slice.get_mapped_range();
         let result_u32s: &[u32] = bytemuck::cast_slice(&data);
 
-        let was_cancelled = cancel.load(Ordering::Relaxed);
-
-        // Calculate the actual number of nonces dispatched to the GPU
-        // This is total_threads * nonces_per_thread, capped at range_size
-        let dispatched_nonces = (total_threads * nonces_per_thread as u64).min(range_size);
+        // Calculate the actual number of nonces dispatched
+        let dispatched_nonces = (total_threads * nonces_per_thread as u64).min(batch_size);
 
         if result_u32s[0] != 0 {
             // Solution found!
@@ -524,94 +586,32 @@ impl MinerEngine for GpuEngine {
             let hash = U512::from_little_endian(bytemuck::cast_slice(hash_u32s));
             let work = nonce.to_big_endian();
 
-            // Calculate hashes computed based on GPU parallel execution model.
-            //
-            // GPU threads process nonces in parallel, not sequentially:
-            // - Thread T processes nonces: start + T*nonces_per_thread + 0, +1, +2, ...
-            // - All threads run approximately in lockstep (SIMT execution)
-            //
-            // When thread T finds a solution at its iteration J:
-            // - logical_index = nonce - start = T * nonces_per_thread + J
-            // - winning_iteration = logical_index % nonces_per_thread = J
-            // - All threads have progressed to approximately iteration J
-            // - Total hashes ≈ total_threads * (J + 1)
-            //
-            // This gives a consistent hash rate regardless of which thread finds the solution.
-            let hashes_computed = if nonce >= range.start {
-                let logical_index = (nonce - range.start).as_u64();
+            // Calculate hashes computed based on GPU parallel execution model
+            let hashes_computed = if nonce >= batch_start {
+                let logical_index = (nonce - batch_start).as_u64();
                 let winning_iteration = logical_index % (nonces_per_thread as u64);
-                // All threads processed approximately (winning_iteration + 1) nonces each
                 (total_threads * (winning_iteration + 1)).min(dispatched_nonces)
             } else {
-                // Shouldn't happen, but fall back to dispatched count
                 dispatched_nonces
             };
 
             drop(data);
             resources.staging_buffer.unmap();
 
-            let hash_rate = hashes_computed as f64 / search_elapsed.as_secs_f64();
-
-            log::debug!(
-                target: "gpu_engine",
-                "GPU {} found solution! Nonce: {}, Hash: {} ({} hashes in {:.2}s, {})",
-                device_index,
-                format_u512(nonce),
-                format_u512(hash),
-                hashes_computed,
-                search_elapsed.as_secs_f64(),
-                format_hashrate(hash_rate)
-            );
-
-            return EngineStatus::Found {
+            return BatchResult::Found {
                 candidate: Candidate { nonce, work, hash },
                 hash_count: hashes_computed,
-                origin: FoundOrigin::GpuG1,
             };
         }
 
         drop(data);
         resources.staging_buffer.unmap();
 
-        if was_cancelled {
-            // For cancelled jobs, estimate hashes based on elapsed time and dispatched work.
-            // The shader checks cancel flag periodically, so we estimate based on how much
-            // of the dispatch likely completed. This is approximate but better than 0.
-            // We use the ratio of elapsed time to expected completion time.
-            // As a simple heuristic, if the GPU was running, it was doing work.
-            // We report dispatched_nonces as upper bound since the dispatch was submitted.
-            // In practice, cancellation happens quickly so this is often close to 0 useful hashes.
-            let estimated_hashes = dispatched_nonces;
-            log::info!(
-                target: "gpu_engine",
-                "GPU {} search cancelled after {:.2}s (~{} hashes dispatched)",
-                device_index,
-                search_elapsed.as_secs_f64(),
-                estimated_hashes
-            );
-            return EngineStatus::Cancelled {
-                hash_count: estimated_hashes,
-            };
-        }
-
-        // Range exhausted without finding solution - all dispatched nonces were processed
-        let hash_rate = dispatched_nonces as f64 / search_elapsed.as_secs_f64();
-        log::info!(
-            target: "gpu_engine",
-            "GPU {} search exhausted: {} hashes in {:.2}s ({})",
-            device_index,
-            dispatched_nonces,
-            search_elapsed.as_secs_f64(),
-            format_hashrate(hash_rate)
-        );
-
-        EngineStatus::Exhausted {
+        BatchResult::NotFound {
             hash_count: dispatched_nonces,
         }
     }
-}
 
-impl GpuEngine {
     /// Get vendor-specific optimal dispatch configuration
     fn get_vendor_specific_dispatch(
         adapter_info: &wgpu::AdapterInfo,

--- a/crates/engine-gpu/src/lib.rs
+++ b/crates/engine-gpu/src/lib.rs
@@ -12,7 +12,7 @@ use std::sync::{
 };
 
 /// Default interval for checking cancel flag in shader (in nonces)
-const DEFAULT_CANCEL_CHECK_INTERVAL: u32 = 10_000;
+const DEFAULT_CANCEL_CHECK_INTERVAL: u32 = 100_000;
 
 /// Represents a single GPU device context.
 struct GpuContext {
@@ -204,21 +204,7 @@ impl GpuEngine {
         let mut adapter_infos = Vec::new();
         for (i, adapter) in adapters.into_iter().enumerate() {
             let info = adapter.get_info();
-            log::info!(
-                "Initializing GPU adapter {}: {} (Backend: {:?})",
-                i,
-                info.name,
-                info.backend
-            );
-            log::info!(target: "gpu_engine", "Adapter {} detailed info:", i);
-            log::info!(target: "gpu_engine", "  Name: {}", info.name);
-            log::info!(target: "gpu_engine", "  Vendor: {}", info.vendor);
-            log::info!(target: "gpu_engine", "  Device: {}", info.device);
-            log::info!(target: "gpu_engine", "  Device Type: {:?}", info.device_type);
-            log::info!(target: "gpu_engine", "  Driver: {}", info.driver);
-            log::info!(target: "gpu_engine", "  Driver Info: {}", info.driver_info);
-            log::info!(target: "gpu_engine", "  Backend: {:?}", info.backend);
-            log::debug!(target: "gpu_engine", "Adapter {} full info: {:?}", i, info);
+            log::debug!(target: "gpu_engine", "Adapter {} raw info: {:?}", i, info);
             adapter_infos.push(info.clone());
 
             let (device, queue) = adapter
@@ -231,15 +217,16 @@ impl GpuEngine {
                 })
                 .await?;
 
-            log::debug!(target: "gpu_engine", "Device and Queue requested for adapter {}", i);
-            log::info!(target: "gpu_engine", "Device limits for adapter {}:", i);
+            // Log device limits at debug level
             let limits = device.limits();
-            log::info!(target: "gpu_engine", "  Max workgroups per dimension: {}", limits.max_compute_workgroups_per_dimension);
-            log::info!(target: "gpu_engine", "  Max workgroup size X: {}", limits.max_compute_workgroup_size_x);
-            log::info!(target: "gpu_engine", "  Max workgroup size Y: {}", limits.max_compute_workgroup_size_y);
-            log::info!(target: "gpu_engine", "  Max workgroup size Z: {}", limits.max_compute_workgroup_size_z);
-            log::info!(target: "gpu_engine", "  Max compute invocations per workgroup: {}", limits.max_compute_invocations_per_workgroup);
-            log::info!(target: "gpu_engine", "  Max buffer size: {}", limits.max_buffer_size);
+            log::debug!(target: "gpu_engine", "Adapter {} limits: max_workgroups={}, max_workgroup_size={}x{}x{}, max_buffer={}",
+                i,
+                limits.max_compute_workgroups_per_dimension,
+                limits.max_compute_workgroup_size_x,
+                limits.max_compute_workgroup_size_y,
+                limits.max_compute_workgroup_size_z,
+                limits.max_buffer_size
+            );
 
             let shader_source = include_str!("mining.wgsl");
             let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
@@ -638,82 +625,139 @@ impl GpuEngine {
         let _device_name = adapter_info.device.to_string().to_lowercase();
 
         // Vendor-specific heuristics based on architecture knowledge
-        let optimal_workgroups = if vendor_name.contains("nvidia") || adapter_info.vendor == 4318 {
+        // Returns (workgroups, tier_name, is_fallback)
+        let (optimal_workgroups, tier, is_fallback) = if vendor_name.contains("nvidia") || adapter_info.vendor == 4318 {
             // NVIDIA GPUs (vendor ID 0x10DE = 4318)
-            if vendor_name.contains("rtx 40") || vendor_name.contains("rtx 4090") {
-                (max_workgroups / 8).max(4096)
-            } else if vendor_name.contains("rtx 30") || vendor_name.contains("rtx 20") {
-                (max_workgroups / 12).max(2048)
-            } else if vendor_name.contains("gtx") || vendor_name.contains("rtx 16") {
-                (max_workgroups / 16).max(1024)
+            if vendor_name.contains("5090") || vendor_name.contains("5080") {
+                ((max_workgroups / 6).max(5120), "NVIDIA RTX 50 Flagship (Blackwell)", false)
+            } else if vendor_name.contains("5070") || vendor_name.contains("5060") || vendor_name.contains("rtx 50") {
+                ((max_workgroups / 7).max(4608), "NVIDIA RTX 50 (Blackwell)", false)
+            } else if vendor_name.contains("4090") || vendor_name.contains("4080") {
+                ((max_workgroups / 8).max(4096), "NVIDIA RTX 40 Flagship (Ada)", false)
+            } else if vendor_name.contains("rtx 40") || vendor_name.contains("4070") || vendor_name.contains("4060") {
+                ((max_workgroups / 10).max(3072), "NVIDIA RTX 40 (Ada)", false)
+            } else if vendor_name.contains("rtx 30") || vendor_name.contains("rtx 20")
+                || vendor_name.contains("3090") || vendor_name.contains("3080") || vendor_name.contains("3070")
+                || vendor_name.contains("2080") || vendor_name.contains("2070") || vendor_name.contains("2060") {
+                ((max_workgroups / 12).max(2048), "NVIDIA RTX 30/20 (Ampere/Turing)", false)
+            } else if vendor_name.contains("gtx 16") || vendor_name.contains("gtx 10")
+                || vendor_name.contains("1660") || vendor_name.contains("1650")
+                || vendor_name.contains("1080") || vendor_name.contains("1070") || vendor_name.contains("1060") {
+                ((max_workgroups / 16).max(1024), "NVIDIA GTX 16/10 (Turing/Pascal)", false)
+            } else if vendor_name.contains("gtx") {
+                ((max_workgroups / 18).max(768), "NVIDIA GTX (Legacy)", false)
+            } else if vendor_name.contains("quadro") || vendor_name.contains("rtx a") || vendor_name.contains("tesla") {
+                ((max_workgroups / 10).max(2560), "NVIDIA Quadro/Professional", false)
             } else {
-                (max_workgroups / 20).max(512)
+                ((max_workgroups / 20).max(512), "NVIDIA Unknown", true)
             }
-        } else if vendor_name.contains("amd") || adapter_info.vendor == 4098 {
+        } else if vendor_name.contains("amd") || vendor_name.contains("radeon") || adapter_info.vendor == 4098 {
             // AMD GPUs (vendor ID 0x1002 = 4098)
-            if vendor_name.contains("rx 7") || vendor_name.contains("rx 6900") {
-                (max_workgroups / 10).max(3072)
-            } else if vendor_name.contains("rx 6") || vendor_name.contains("rx 5700") {
-                (max_workgroups / 14).max(2048)
-            } else if vendor_name.contains("rx 5") || vendor_name.contains("rx 580") {
-                (max_workgroups / 18).max(1024)
+            if vendor_name.contains("rx 9") || vendor_name.contains("9070") || vendor_name.contains("9080") {
+                ((max_workgroups / 8).max(4096), "AMD RX 9000 (RDNA 4)", false)
+            } else if vendor_name.contains("7900") {
+                ((max_workgroups / 9).max(3584), "AMD RX 7900 (RDNA 3 Flagship)", false)
+            } else if vendor_name.contains("rx 7") || vendor_name.contains("7800") || vendor_name.contains("7700") || vendor_name.contains("7600") {
+                ((max_workgroups / 10).max(3072), "AMD RX 7000 (RDNA 3)", false)
+            } else if vendor_name.contains("6900") || vendor_name.contains("6800") {
+                ((max_workgroups / 12).max(2560), "AMD RX 6900/6800 (RDNA 2 Flagship)", false)
+            } else if vendor_name.contains("rx 6") || vendor_name.contains("6700") || vendor_name.contains("6600") {
+                ((max_workgroups / 14).max(2048), "AMD RX 6000 (RDNA 2)", false)
+            } else if vendor_name.contains("5700") {
+                ((max_workgroups / 16).max(1536), "AMD RX 5700 (RDNA 1)", false)
+            } else if vendor_name.contains("rx 5") || vendor_name.contains("5600") || vendor_name.contains("5500") {
+                ((max_workgroups / 18).max(1024), "AMD RX 5000 (RDNA 1)", false)
+            } else if vendor_name.contains("rx 4") || vendor_name.contains("580") || vendor_name.contains("570") {
+                ((max_workgroups / 20).max(768), "AMD RX 500/400 (Polaris)", false)
+            } else if vendor_name.contains("radeon pro") || vendor_name.contains("instinct") || vendor_name.contains("mi") {
+                ((max_workgroups / 10).max(2560), "AMD Radeon Pro/Instinct", false)
             } else {
-                (max_workgroups / 24).max(512)
+                ((max_workgroups / 24).max(512), "AMD Unknown", true)
             }
         } else if vendor_name.contains("intel") || adapter_info.vendor == 32902 {
             // Intel GPUs (vendor ID 0x8086 = 32902)
-            if vendor_name.contains("arc a7") || vendor_name.contains("arc a770") {
-                (max_workgroups / 12).max(2048)
-            } else if vendor_name.contains("arc a5") || vendor_name.contains("arc a380") {
-                (max_workgroups / 16).max(1024)
-            } else if vendor_name.contains("iris xe") {
-                (max_workgroups / 20).max(512)
+            if vendor_name.contains("arc b") || vendor_name.contains("b580") || vendor_name.contains("b570") {
+                ((max_workgroups / 10).max(2560), "Intel Arc B-Series (Battlemage)", false)
+            } else if vendor_name.contains("a770") || vendor_name.contains("a750") {
+                ((max_workgroups / 12).max(2048), "Intel Arc A7 (Alchemist)", false)
+            } else if vendor_name.contains("a580") || vendor_name.contains("a380") || vendor_name.contains("arc a5") || vendor_name.contains("arc a3") {
+                ((max_workgroups / 16).max(1024), "Intel Arc A5/A3 (Alchemist)", false)
+            } else if vendor_name.contains("a310") {
+                ((max_workgroups / 20).max(512), "Intel Arc A3 Entry", false)
+            } else if vendor_name.contains("iris xe") || vendor_name.contains("iris plus") {
+                ((max_workgroups / 24).max(384), "Intel Iris Xe/Plus (Integrated)", false)
+            } else if vendor_name.contains("uhd") || vendor_name.contains("hd graphics") {
+                ((max_workgroups / 28).max(256), "Intel UHD/HD Graphics (Integrated)", false)
             } else {
-                (max_workgroups / 24).max(256)
+                ((max_workgroups / 24).max(256), "Intel Unknown", true)
             }
         } else if adapter_info.backend == wgpu::Backend::Metal {
             // Apple GPUs (detected by Metal backend)
-            let (gpu_cores, workgroups) = if vendor_name.contains("m4 max") {
-                (40, 800)
+            let (gpu_cores, workgroups, tier) = if vendor_name.contains("m4 ultra") {
+                (80, 1600, "Apple M4 Ultra")
+            } else if vendor_name.contains("m4 max") {
+                (40, 800, "Apple M4 Max")
             } else if vendor_name.contains("m4 pro") {
-                (20, 400)
+                (20, 400, "Apple M4 Pro")
             } else if vendor_name.contains("m4") {
-                (10, 200)
+                (10, 200, "Apple M4")
+            } else if vendor_name.contains("m3 ultra") {
+                (76, 1520, "Apple M3 Ultra")
             } else if vendor_name.contains("m3 max") {
-                (40, 800)
+                (40, 800, "Apple M3 Max")
             } else if vendor_name.contains("m3 pro") {
-                (18, 360)
+                (18, 360, "Apple M3 Pro")
             } else if vendor_name.contains("m3") {
-                (10, 200)
+                (10, 200, "Apple M3")
             } else if vendor_name.contains("m2 ultra") {
-                (76, 1520)
+                (76, 1520, "Apple M2 Ultra")
             } else if vendor_name.contains("m2 max") {
-                (38, 760)
+                (38, 760, "Apple M2 Max")
             } else if vendor_name.contains("m2 pro") {
-                (19, 380)
+                (19, 380, "Apple M2 Pro")
             } else if vendor_name.contains("m2") {
-                (10, 200)
+                (10, 200, "Apple M2")
             } else if vendor_name.contains("m1 ultra") {
-                (64, 1280)
+                (64, 1280, "Apple M1 Ultra")
             } else if vendor_name.contains("m1 max") {
-                (32, 640)
+                (32, 640, "Apple M1 Max")
             } else if vendor_name.contains("m1 pro") {
-                (16, 320)
+                (16, 320, "Apple M1 Pro")
+            } else if vendor_name.contains("m1") {
+                (8, 160, "Apple M1")
             } else {
-                (8, 160)
+                (8, 160, "Apple Silicon Unknown")
             };
 
             let clamped_workgroups = workgroups.min(max_workgroups / 4).max(64);
             let _ = gpu_cores; // gpu_cores currently unused but kept for potential future tuning
-            clamped_workgroups
+            let is_fallback = tier == "Apple Silicon Unknown";
+            (clamped_workgroups, tier, is_fallback)
         } else {
             // Unknown/Generic GPU - use conservative defaults
-            (max_workgroups / 16).max(512)
+            ((max_workgroups / 16).max(512), "Unknown GPU", true)
         };
 
-        log::info!(target: "gpu_engine", "Vendor-specific dispatch configuration:");
-        log::info!(target: "gpu_engine", "  Max hardware workgroups: {}", max_workgroups);
-        log::info!(target: "gpu_engine", "  Optimal workgroups: {}", optimal_workgroups);
+        // Log GPU detection result
+        log::info!(
+            target: "gpu_engine",
+            "GPU detected: {} | tier: {} | workgroups: {} (max: {})",
+            adapter_info.name,
+            tier,
+            optimal_workgroups,
+            max_workgroups
+        );
+
+        if is_fallback {
+            log::warn!(
+                target: "gpu_engine",
+                "GPU not recognized, using fallback config. Please report: name='{}', vendor=0x{:04X}, device={}",
+                adapter_info.name,
+                adapter_info.vendor,
+                adapter_info.device
+            );
+            log::warn!(target: "gpu_engine", "Report at: https://github.com/Quantus-Network/quantus-miner/issues");
+        }
 
         optimal_workgroups
     }

--- a/crates/engine-gpu/src/lib.rs
+++ b/crates/engine-gpu/src/lib.rs
@@ -11,9 +11,7 @@ use std::sync::{
     Arc,
 };
 
-/// Default batch size for GPU processing (in nonces)
-/// 10 million nonces per batch = ~50-500ms per batch depending on GPU
-const DEFAULT_BATCH_SIZE: u64 = 10_000_000;
+
 
 /// Represents a single GPU device context.
 struct GpuContext {
@@ -141,28 +139,10 @@ impl GpuContext {
     }
 }
 
-impl Default for GpuEngine {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl GpuEngine {
-    pub fn new() -> Self {
-        block_on(Self::init(DEFAULT_BATCH_SIZE))
-            .expect("Failed to initialize GPU engine")
-    }
-
-    /// Try to initialize the GPU engine, returning an error if initialization fails.
-    pub fn try_new() -> Result<Self, Box<dyn std::error::Error>> {
-        block_on(Self::init(DEFAULT_BATCH_SIZE))
-    }
-
-    /// Try to initialize the GPU engine with custom batch size.
-    pub fn try_with_batch_size(
-        batch_size: Option<u64>,
-    ) -> Result<Self, Box<dyn std::error::Error>> {
-        block_on(Self::init(batch_size.unwrap_or(DEFAULT_BATCH_SIZE)))
+    /// Try to initialize the GPU engine with the given batch size.
+    pub fn try_new(batch_size: u64) -> Result<Self, Box<dyn std::error::Error>> {
+        block_on(Self::init(batch_size))
     }
 
     async fn init(batch_size: u64) -> Result<Self, Box<dyn std::error::Error>> {
@@ -373,13 +353,15 @@ impl MinerEngine for GpuEngine {
             // Check for cancellation at host level BEFORE starting each batch
             if cancel.is_cancelled() {
                 let elapsed = search_start.elapsed();
+                let hash_rate = total_hashes as f64 / elapsed.as_secs_f64();
                 log::info!(
                     target: "gpu_engine",
-                    "GPU {} cancelled before batch {} ({} total hashes in {:.2}s)",
+                    "GPU {} cancelled before batch {} ({} total hashes in {:.2}s, {})",
                     device_index,
                     batch_num,
                     total_hashes,
-                    elapsed.as_secs_f64()
+                    elapsed.as_secs_f64(),
+                    format_hashrate(hash_rate)
                 );
                 return EngineStatus::Cancelled {
                     hash_count: total_hashes,

--- a/crates/engine-gpu/src/lib.rs
+++ b/crates/engine-gpu/src/lib.rs
@@ -11,8 +11,6 @@ use std::sync::{
     Arc,
 };
 
-
-
 /// Represents a single GPU device context.
 struct GpuContext {
     device: wgpu::Device,
@@ -259,7 +257,12 @@ impl MinerEngine for GpuEngine {
         self
     }
 
-    fn search_range(&self, ctx: &JobContext, range: Range, cancel: &dyn CancelCheck) -> EngineStatus {
+    fn search_range(
+        &self,
+        ctx: &JobContext,
+        range: Range,
+        cancel: &dyn CancelCheck,
+    ) -> EngineStatus {
         if self.contexts.is_empty() {
             log::warn!(target: "gpu_engine", "No GPUs available for search.");
             return EngineStatus::Exhausted { hash_count: 0 };
@@ -369,7 +372,10 @@ impl MinerEngine for GpuEngine {
             }
 
             // Calculate batch range
-            let remaining = range.end.saturating_sub(current_start).saturating_add(U512::one());
+            let remaining = range
+                .end
+                .saturating_sub(current_start)
+                .saturating_add(U512::one());
             let batch_size_u512 = U512::from(self.batch_size);
             let this_batch_size = if remaining > batch_size_u512 {
                 self.batch_size
@@ -378,15 +384,14 @@ impl MinerEngine for GpuEngine {
             };
 
             // Run single batch
-            let batch_result = self.run_single_batch(
-                gpu_ctx,
-                &resources,
-                current_start,
-                this_batch_size,
-            );
+            let batch_result =
+                self.run_single_batch(gpu_ctx, &resources, current_start, this_batch_size);
 
             match batch_result {
-                BatchResult::Found { candidate, hash_count } => {
+                BatchResult::Found {
+                    candidate,
+                    hash_count,
+                } => {
                     total_hashes += hash_count;
                     let elapsed = search_start.elapsed();
                     let hash_rate = total_hashes as f64 / elapsed.as_secs_f64();
@@ -455,8 +460,13 @@ impl MinerEngine for GpuEngine {
 
 /// Result from a single GPU batch
 enum BatchResult {
-    Found { candidate: Candidate, hash_count: u64 },
-    NotFound { hash_count: u64 },
+    Found {
+        candidate: Candidate,
+        hash_count: u64,
+    },
+    NotFound {
+        hash_count: u64,
+    },
 }
 
 impl GpuEngine {
@@ -482,11 +492,7 @@ impl GpuEngine {
         let nonces_per_thread = (batch_size.div_ceil(total_threads)).max(1) as u32;
 
         // Dispatch config: [total_threads, nonces_per_thread, total_nonces]
-        let dispatch_config = [
-            total_threads as u32,
-            nonces_per_thread,
-            batch_size as u32,
-        ];
+        let dispatch_config = [total_threads as u32, nonces_per_thread, batch_size as u32];
 
         // Write dispatch config
         gpu_ctx.queue.write_buffer(
@@ -608,117 +614,251 @@ impl GpuEngine {
 
         // Vendor-specific heuristics based on architecture knowledge
         // Returns (workgroups, tier_name, is_fallback)
-        let (optimal_workgroups, tier, is_fallback) = if vendor_name.contains("nvidia") || adapter_info.vendor == 4318 {
-            // NVIDIA GPUs (vendor ID 0x10DE = 4318)
-            if vendor_name.contains("5090") || vendor_name.contains("5080") {
-                ((max_workgroups / 6).max(5120), "NVIDIA RTX 50 Flagship (Blackwell)", false)
-            } else if vendor_name.contains("5070") || vendor_name.contains("5060") || vendor_name.contains("rtx 50") {
-                ((max_workgroups / 7).max(4608), "NVIDIA RTX 50 (Blackwell)", false)
-            } else if vendor_name.contains("4090") || vendor_name.contains("4080") {
-                ((max_workgroups / 8).max(4096), "NVIDIA RTX 40 Flagship (Ada)", false)
-            } else if vendor_name.contains("rtx 40") || vendor_name.contains("4070") || vendor_name.contains("4060") {
-                ((max_workgroups / 10).max(3072), "NVIDIA RTX 40 (Ada)", false)
-            } else if vendor_name.contains("rtx 30") || vendor_name.contains("rtx 20")
-                || vendor_name.contains("3090") || vendor_name.contains("3080") || vendor_name.contains("3070")
-                || vendor_name.contains("2080") || vendor_name.contains("2070") || vendor_name.contains("2060") {
-                ((max_workgroups / 12).max(2048), "NVIDIA RTX 30/20 (Ampere/Turing)", false)
-            } else if vendor_name.contains("gtx 16") || vendor_name.contains("gtx 10")
-                || vendor_name.contains("1660") || vendor_name.contains("1650")
-                || vendor_name.contains("1080") || vendor_name.contains("1070") || vendor_name.contains("1060") {
-                ((max_workgroups / 16).max(1024), "NVIDIA GTX 16/10 (Turing/Pascal)", false)
-            } else if vendor_name.contains("gtx") {
-                ((max_workgroups / 18).max(768), "NVIDIA GTX (Legacy)", false)
-            } else if vendor_name.contains("quadro") || vendor_name.contains("rtx a") || vendor_name.contains("tesla") {
-                ((max_workgroups / 10).max(2560), "NVIDIA Quadro/Professional", false)
-            } else {
-                ((max_workgroups / 20).max(512), "NVIDIA Unknown", true)
-            }
-        } else if vendor_name.contains("amd") || vendor_name.contains("radeon") || adapter_info.vendor == 4098 {
-            // AMD GPUs (vendor ID 0x1002 = 4098)
-            if vendor_name.contains("rx 9") || vendor_name.contains("9070") || vendor_name.contains("9080") {
-                ((max_workgroups / 8).max(4096), "AMD RX 9000 (RDNA 4)", false)
-            } else if vendor_name.contains("7900") {
-                ((max_workgroups / 9).max(3584), "AMD RX 7900 (RDNA 3 Flagship)", false)
-            } else if vendor_name.contains("rx 7") || vendor_name.contains("7800") || vendor_name.contains("7700") || vendor_name.contains("7600") {
-                ((max_workgroups / 10).max(3072), "AMD RX 7000 (RDNA 3)", false)
-            } else if vendor_name.contains("6900") || vendor_name.contains("6800") {
-                ((max_workgroups / 12).max(2560), "AMD RX 6900/6800 (RDNA 2 Flagship)", false)
-            } else if vendor_name.contains("rx 6") || vendor_name.contains("6700") || vendor_name.contains("6600") {
-                ((max_workgroups / 14).max(2048), "AMD RX 6000 (RDNA 2)", false)
-            } else if vendor_name.contains("5700") {
-                ((max_workgroups / 16).max(1536), "AMD RX 5700 (RDNA 1)", false)
-            } else if vendor_name.contains("rx 5") || vendor_name.contains("5600") || vendor_name.contains("5500") {
-                ((max_workgroups / 18).max(1024), "AMD RX 5000 (RDNA 1)", false)
-            } else if vendor_name.contains("rx 4") || vendor_name.contains("580") || vendor_name.contains("570") {
-                ((max_workgroups / 20).max(768), "AMD RX 500/400 (Polaris)", false)
-            } else if vendor_name.contains("radeon pro") || vendor_name.contains("instinct") || vendor_name.contains("mi") {
-                ((max_workgroups / 10).max(2560), "AMD Radeon Pro/Instinct", false)
-            } else {
-                ((max_workgroups / 24).max(512), "AMD Unknown", true)
-            }
-        } else if vendor_name.contains("intel") || adapter_info.vendor == 32902 {
-            // Intel GPUs (vendor ID 0x8086 = 32902)
-            if vendor_name.contains("arc b") || vendor_name.contains("b580") || vendor_name.contains("b570") {
-                ((max_workgroups / 10).max(2560), "Intel Arc B-Series (Battlemage)", false)
-            } else if vendor_name.contains("a770") || vendor_name.contains("a750") {
-                ((max_workgroups / 12).max(2048), "Intel Arc A7 (Alchemist)", false)
-            } else if vendor_name.contains("a580") || vendor_name.contains("a380") || vendor_name.contains("arc a5") || vendor_name.contains("arc a3") {
-                ((max_workgroups / 16).max(1024), "Intel Arc A5/A3 (Alchemist)", false)
-            } else if vendor_name.contains("a310") {
-                ((max_workgroups / 20).max(512), "Intel Arc A3 Entry", false)
-            } else if vendor_name.contains("iris xe") || vendor_name.contains("iris plus") {
-                ((max_workgroups / 24).max(384), "Intel Iris Xe/Plus (Integrated)", false)
-            } else if vendor_name.contains("uhd") || vendor_name.contains("hd graphics") {
-                ((max_workgroups / 28).max(256), "Intel UHD/HD Graphics (Integrated)", false)
-            } else {
-                ((max_workgroups / 24).max(256), "Intel Unknown", true)
-            }
-        } else if adapter_info.backend == wgpu::Backend::Metal {
-            // Apple GPUs (detected by Metal backend)
-            let (gpu_cores, workgroups, tier) = if vendor_name.contains("m4 ultra") {
-                (80, 1600, "Apple M4 Ultra")
-            } else if vendor_name.contains("m4 max") {
-                (40, 800, "Apple M4 Max")
-            } else if vendor_name.contains("m4 pro") {
-                (20, 400, "Apple M4 Pro")
-            } else if vendor_name.contains("m4") {
-                (10, 200, "Apple M4")
-            } else if vendor_name.contains("m3 ultra") {
-                (76, 1520, "Apple M3 Ultra")
-            } else if vendor_name.contains("m3 max") {
-                (40, 800, "Apple M3 Max")
-            } else if vendor_name.contains("m3 pro") {
-                (18, 360, "Apple M3 Pro")
-            } else if vendor_name.contains("m3") {
-                (10, 200, "Apple M3")
-            } else if vendor_name.contains("m2 ultra") {
-                (76, 1520, "Apple M2 Ultra")
-            } else if vendor_name.contains("m2 max") {
-                (38, 760, "Apple M2 Max")
-            } else if vendor_name.contains("m2 pro") {
-                (19, 380, "Apple M2 Pro")
-            } else if vendor_name.contains("m2") {
-                (10, 200, "Apple M2")
-            } else if vendor_name.contains("m1 ultra") {
-                (64, 1280, "Apple M1 Ultra")
-            } else if vendor_name.contains("m1 max") {
-                (32, 640, "Apple M1 Max")
-            } else if vendor_name.contains("m1 pro") {
-                (16, 320, "Apple M1 Pro")
-            } else if vendor_name.contains("m1") {
-                (8, 160, "Apple M1")
-            } else {
-                (8, 160, "Apple Silicon Unknown")
-            };
+        let (optimal_workgroups, tier, is_fallback) =
+            if vendor_name.contains("nvidia") || adapter_info.vendor == 4318 {
+                // NVIDIA GPUs (vendor ID 0x10DE = 4318)
+                if vendor_name.contains("5090") || vendor_name.contains("5080") {
+                    (
+                        (max_workgroups / 6).max(5120),
+                        "NVIDIA RTX 50 Flagship (Blackwell)",
+                        false,
+                    )
+                } else if vendor_name.contains("5070")
+                    || vendor_name.contains("5060")
+                    || vendor_name.contains("rtx 50")
+                {
+                    (
+                        (max_workgroups / 7).max(4608),
+                        "NVIDIA RTX 50 (Blackwell)",
+                        false,
+                    )
+                } else if vendor_name.contains("4090") || vendor_name.contains("4080") {
+                    (
+                        (max_workgroups / 8).max(4096),
+                        "NVIDIA RTX 40 Flagship (Ada)",
+                        false,
+                    )
+                } else if vendor_name.contains("rtx 40")
+                    || vendor_name.contains("4070")
+                    || vendor_name.contains("4060")
+                {
+                    (
+                        (max_workgroups / 10).max(3072),
+                        "NVIDIA RTX 40 (Ada)",
+                        false,
+                    )
+                } else if vendor_name.contains("rtx 30")
+                    || vendor_name.contains("rtx 20")
+                    || vendor_name.contains("3090")
+                    || vendor_name.contains("3080")
+                    || vendor_name.contains("3070")
+                    || vendor_name.contains("2080")
+                    || vendor_name.contains("2070")
+                    || vendor_name.contains("2060")
+                {
+                    (
+                        (max_workgroups / 12).max(2048),
+                        "NVIDIA RTX 30/20 (Ampere/Turing)",
+                        false,
+                    )
+                } else if vendor_name.contains("gtx 16")
+                    || vendor_name.contains("gtx 10")
+                    || vendor_name.contains("1660")
+                    || vendor_name.contains("1650")
+                    || vendor_name.contains("1080")
+                    || vendor_name.contains("1070")
+                    || vendor_name.contains("1060")
+                {
+                    (
+                        (max_workgroups / 16).max(1024),
+                        "NVIDIA GTX 16/10 (Turing/Pascal)",
+                        false,
+                    )
+                } else if vendor_name.contains("gtx") {
+                    ((max_workgroups / 18).max(768), "NVIDIA GTX (Legacy)", false)
+                } else if vendor_name.contains("quadro")
+                    || vendor_name.contains("rtx a")
+                    || vendor_name.contains("tesla")
+                {
+                    (
+                        (max_workgroups / 10).max(2560),
+                        "NVIDIA Quadro/Professional",
+                        false,
+                    )
+                } else {
+                    ((max_workgroups / 20).max(512), "NVIDIA Unknown", true)
+                }
+            } else if vendor_name.contains("amd")
+                || vendor_name.contains("radeon")
+                || adapter_info.vendor == 4098
+            {
+                // AMD GPUs (vendor ID 0x1002 = 4098)
+                if vendor_name.contains("rx 9")
+                    || vendor_name.contains("9070")
+                    || vendor_name.contains("9080")
+                {
+                    (
+                        (max_workgroups / 8).max(4096),
+                        "AMD RX 9000 (RDNA 4)",
+                        false,
+                    )
+                } else if vendor_name.contains("7900") {
+                    (
+                        (max_workgroups / 9).max(3584),
+                        "AMD RX 7900 (RDNA 3 Flagship)",
+                        false,
+                    )
+                } else if vendor_name.contains("rx 7")
+                    || vendor_name.contains("7800")
+                    || vendor_name.contains("7700")
+                    || vendor_name.contains("7600")
+                {
+                    (
+                        (max_workgroups / 10).max(3072),
+                        "AMD RX 7000 (RDNA 3)",
+                        false,
+                    )
+                } else if vendor_name.contains("6900") || vendor_name.contains("6800") {
+                    (
+                        (max_workgroups / 12).max(2560),
+                        "AMD RX 6900/6800 (RDNA 2 Flagship)",
+                        false,
+                    )
+                } else if vendor_name.contains("rx 6")
+                    || vendor_name.contains("6700")
+                    || vendor_name.contains("6600")
+                {
+                    (
+                        (max_workgroups / 14).max(2048),
+                        "AMD RX 6000 (RDNA 2)",
+                        false,
+                    )
+                } else if vendor_name.contains("5700") {
+                    (
+                        (max_workgroups / 16).max(1536),
+                        "AMD RX 5700 (RDNA 1)",
+                        false,
+                    )
+                } else if vendor_name.contains("rx 5")
+                    || vendor_name.contains("5600")
+                    || vendor_name.contains("5500")
+                {
+                    (
+                        (max_workgroups / 18).max(1024),
+                        "AMD RX 5000 (RDNA 1)",
+                        false,
+                    )
+                } else if vendor_name.contains("rx 4")
+                    || vendor_name.contains("580")
+                    || vendor_name.contains("570")
+                {
+                    (
+                        (max_workgroups / 20).max(768),
+                        "AMD RX 500/400 (Polaris)",
+                        false,
+                    )
+                } else if vendor_name.contains("radeon pro")
+                    || vendor_name.contains("instinct")
+                    || vendor_name.contains("mi")
+                {
+                    (
+                        (max_workgroups / 10).max(2560),
+                        "AMD Radeon Pro/Instinct",
+                        false,
+                    )
+                } else {
+                    ((max_workgroups / 24).max(512), "AMD Unknown", true)
+                }
+            } else if vendor_name.contains("intel") || adapter_info.vendor == 32902 {
+                // Intel GPUs (vendor ID 0x8086 = 32902)
+                if vendor_name.contains("arc b")
+                    || vendor_name.contains("b580")
+                    || vendor_name.contains("b570")
+                {
+                    (
+                        (max_workgroups / 10).max(2560),
+                        "Intel Arc B-Series (Battlemage)",
+                        false,
+                    )
+                } else if vendor_name.contains("a770") || vendor_name.contains("a750") {
+                    (
+                        (max_workgroups / 12).max(2048),
+                        "Intel Arc A7 (Alchemist)",
+                        false,
+                    )
+                } else if vendor_name.contains("a580")
+                    || vendor_name.contains("a380")
+                    || vendor_name.contains("arc a5")
+                    || vendor_name.contains("arc a3")
+                {
+                    (
+                        (max_workgroups / 16).max(1024),
+                        "Intel Arc A5/A3 (Alchemist)",
+                        false,
+                    )
+                } else if vendor_name.contains("a310") {
+                    ((max_workgroups / 20).max(512), "Intel Arc A3 Entry", false)
+                } else if vendor_name.contains("iris xe") || vendor_name.contains("iris plus") {
+                    (
+                        (max_workgroups / 24).max(384),
+                        "Intel Iris Xe/Plus (Integrated)",
+                        false,
+                    )
+                } else if vendor_name.contains("uhd") || vendor_name.contains("hd graphics") {
+                    (
+                        (max_workgroups / 28).max(256),
+                        "Intel UHD/HD Graphics (Integrated)",
+                        false,
+                    )
+                } else {
+                    ((max_workgroups / 24).max(256), "Intel Unknown", true)
+                }
+            } else if adapter_info.backend == wgpu::Backend::Metal {
+                // Apple GPUs (detected by Metal backend)
+                let (gpu_cores, workgroups, tier) = if vendor_name.contains("m4 ultra") {
+                    (80, 1600, "Apple M4 Ultra")
+                } else if vendor_name.contains("m4 max") {
+                    (40, 800, "Apple M4 Max")
+                } else if vendor_name.contains("m4 pro") {
+                    (20, 400, "Apple M4 Pro")
+                } else if vendor_name.contains("m4") {
+                    (10, 200, "Apple M4")
+                } else if vendor_name.contains("m3 ultra") {
+                    (76, 1520, "Apple M3 Ultra")
+                } else if vendor_name.contains("m3 max") {
+                    (40, 800, "Apple M3 Max")
+                } else if vendor_name.contains("m3 pro") {
+                    (18, 360, "Apple M3 Pro")
+                } else if vendor_name.contains("m3") {
+                    (10, 200, "Apple M3")
+                } else if vendor_name.contains("m2 ultra") {
+                    (76, 1520, "Apple M2 Ultra")
+                } else if vendor_name.contains("m2 max") {
+                    (38, 760, "Apple M2 Max")
+                } else if vendor_name.contains("m2 pro") {
+                    (19, 380, "Apple M2 Pro")
+                } else if vendor_name.contains("m2") {
+                    (10, 200, "Apple M2")
+                } else if vendor_name.contains("m1 ultra") {
+                    (64, 1280, "Apple M1 Ultra")
+                } else if vendor_name.contains("m1 max") {
+                    (32, 640, "Apple M1 Max")
+                } else if vendor_name.contains("m1 pro") {
+                    (16, 320, "Apple M1 Pro")
+                } else if vendor_name.contains("m1") {
+                    (8, 160, "Apple M1")
+                } else {
+                    (8, 160, "Apple Silicon Unknown")
+                };
 
-            let clamped_workgroups = workgroups.min(max_workgroups / 4).max(64);
-            let _ = gpu_cores; // gpu_cores currently unused but kept for potential future tuning
-            let is_fallback = tier == "Apple Silicon Unknown";
-            (clamped_workgroups, tier, is_fallback)
-        } else {
-            // Unknown/Generic GPU - use conservative defaults
-            ((max_workgroups / 16).max(512), "Unknown GPU", true)
-        };
+                let clamped_workgroups = workgroups.min(max_workgroups / 4).max(64);
+                let _ = gpu_cores; // gpu_cores currently unused but kept for potential future tuning
+                let is_fallback = tier == "Apple Silicon Unknown";
+                (clamped_workgroups, tier, is_fallback)
+            } else {
+                // Unknown/Generic GPU - use conservative defaults
+                ((max_workgroups / 16).max(512), "Unknown GPU", true)
+            };
 
         // Log GPU detection result
         log::info!(

--- a/crates/engine-gpu/src/lib.rs
+++ b/crates/engine-gpu/src/lib.rs
@@ -206,7 +206,7 @@ impl GpuEngine {
             log::debug!(target: "gpu_engine", "Pipeline initialized for adapter {}", i);
 
             // Calculate vendor-specific configuration once during initialization
-            let optimal_workgroups = Self::get_vendor_specific_dispatch(&info, &device);
+            let optimal_workgroups = get_vendor_specific_dispatch(&info, &device);
 
             contexts.push(Arc::new(GpuContext {
                 device,
@@ -385,7 +385,7 @@ impl MinerEngine for GpuEngine {
 
             // Run single batch
             let batch_result =
-                self.run_single_batch(gpu_ctx, &resources, current_start, this_batch_size);
+                run_single_batch(gpu_ctx, &resources, current_start, this_batch_size);
 
             match batch_result {
                 BatchResult::Found {
@@ -469,418 +469,412 @@ enum BatchResult {
     },
 }
 
-impl GpuEngine {
-    /// Run a single batch of GPU computation
-    fn run_single_batch(
-        &self,
-        gpu_ctx: &GpuContext,
-        resources: &GpuResources,
-        batch_start: U512,
-        batch_size: u64,
-    ) -> BatchResult {
-        // Calculate dispatch configuration for this batch
-        let threads_per_workgroup = 256u32;
-        let limits = gpu_ctx.device.limits();
-        let max_workgroups = limits.max_compute_workgroups_per_dimension;
+/// Run a single batch of GPU computation
+fn run_single_batch(
+    gpu_ctx: &GpuContext,
+    resources: &GpuResources,
+    batch_start: U512,
+    batch_size: u64,
+) -> BatchResult {
+    // Calculate dispatch configuration for this batch
+    let threads_per_workgroup = 256u32;
+    let limits = gpu_ctx.device.limits();
+    let max_workgroups = limits.max_compute_workgroups_per_dimension;
 
-        let hinted_workgroups = gpu_ctx.optimal_workgroups.max(1).min(max_workgroups);
-        let hinted_threads = hinted_workgroups as u64 * threads_per_workgroup as u64;
+    let hinted_workgroups = gpu_ctx.optimal_workgroups.max(1).min(max_workgroups);
+    let hinted_threads = hinted_workgroups as u64 * threads_per_workgroup as u64;
 
-        let logical_threads = batch_size.min(hinted_threads).max(1);
-        let num_workgroups = ((logical_threads as u32).div_ceil(threads_per_workgroup)).max(1);
-        let total_threads = (num_workgroups * threads_per_workgroup) as u64;
-        let nonces_per_thread = (batch_size.div_ceil(total_threads)).max(1) as u32;
+    let logical_threads = batch_size.min(hinted_threads).max(1);
+    let num_workgroups = ((logical_threads as u32).div_ceil(threads_per_workgroup)).max(1);
+    let total_threads = (num_workgroups * threads_per_workgroup) as u64;
+    let nonces_per_thread = (batch_size.div_ceil(total_threads)).max(1) as u32;
 
-        // Dispatch config: [total_threads, nonces_per_thread, total_nonces]
-        let dispatch_config = [total_threads as u32, nonces_per_thread, batch_size as u32];
+    // Dispatch config: [total_threads, nonces_per_thread, total_nonces]
+    let dispatch_config = [total_threads as u32, nonces_per_thread, batch_size as u32];
 
-        // Write dispatch config
-        gpu_ctx.queue.write_buffer(
-            &resources.dispatch_config_buffer,
-            0,
-            bytemuck::cast_slice(&dispatch_config),
-        );
+    // Write dispatch config
+    gpu_ctx.queue.write_buffer(
+        &resources.dispatch_config_buffer,
+        0,
+        bytemuck::cast_slice(&dispatch_config),
+    );
 
-        // Write start nonce for this batch
-        let start_nonce_bytes = batch_start.to_little_endian();
-        gpu_ctx
-            .queue
-            .write_buffer(&resources.start_nonce_buffer, 0, &start_nonce_bytes);
+    // Write start nonce for this batch
+    let start_nonce_bytes = batch_start.to_little_endian();
+    gpu_ctx
+        .queue
+        .write_buffer(&resources.start_nonce_buffer, 0, &start_nonce_bytes);
 
-        // Reset results buffer
-        const RESULTS_SIZE: usize = (1 + 16 + 16) * 4;
-        const ZEROS: [u8; RESULTS_SIZE] = [0; RESULTS_SIZE];
-        gpu_ctx
-            .queue
-            .write_buffer(&resources.results_buffer, 0, &ZEROS);
+    // Reset results buffer
+    const RESULTS_SIZE: usize = (1 + 16 + 16) * 4;
+    const ZEROS: [u8; RESULTS_SIZE] = [0; RESULTS_SIZE];
+    gpu_ctx
+        .queue
+        .write_buffer(&resources.results_buffer, 0, &ZEROS);
 
-        // Create and submit command buffer
-        let mut encoder = gpu_ctx
-            .device
-            .create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
-        {
-            let mut cpass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
-                label: None,
-                timestamp_writes: None,
-            });
-            cpass.set_pipeline(&gpu_ctx.pipeline);
-            cpass.set_bind_group(0, &resources.bind_group, &[]);
-            cpass.dispatch_workgroups(num_workgroups, 1, 1);
+    // Create and submit command buffer
+    let mut encoder = gpu_ctx
+        .device
+        .create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+    {
+        let mut cpass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+            label: None,
+            timestamp_writes: None,
+        });
+        cpass.set_pipeline(&gpu_ctx.pipeline);
+        cpass.set_bind_group(0, &resources.bind_group, &[]);
+        cpass.dispatch_workgroups(num_workgroups, 1, 1);
+    }
+    encoder.copy_buffer_to_buffer(
+        &resources.results_buffer,
+        0,
+        &resources.staging_buffer,
+        0,
+        RESULTS_SIZE as u64,
+    );
+
+    gpu_ctx.queue.submit(Some(encoder.finish()));
+
+    // Wait for GPU to complete (blocking)
+    let buffer_slice = resources.staging_buffer.slice(..);
+    let mapped = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let mapped_clone = mapped.clone();
+    buffer_slice.map_async(wgpu::MapMode::Read, move |result| {
+        if result.is_ok() {
+            mapped_clone.store(true, Ordering::Release);
         }
-        encoder.copy_buffer_to_buffer(
-            &resources.results_buffer,
-            0,
-            &resources.staging_buffer,
-            0,
-            RESULTS_SIZE as u64,
-        );
+    });
 
-        gpu_ctx.queue.submit(Some(encoder.finish()));
-
-        // Wait for GPU to complete (blocking)
-        let buffer_slice = resources.staging_buffer.slice(..);
-        let mapped = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
-        let mapped_clone = mapped.clone();
-        buffer_slice.map_async(wgpu::MapMode::Read, move |result| {
-            if result.is_ok() {
-                mapped_clone.store(true, Ordering::Release);
-            }
+    // Poll until complete
+    loop {
+        let _ = gpu_ctx.device.poll(wgpu::PollType::Wait {
+            submission_index: None,
+            timeout: Some(std::time::Duration::from_millis(10)),
         });
 
-        // Poll until complete
-        loop {
-            let _ = gpu_ctx.device.poll(wgpu::PollType::Wait {
-                submission_index: None,
-                timeout: Some(std::time::Duration::from_millis(10)),
-            });
-
-            if mapped.load(Ordering::Acquire) {
-                break;
-            }
+        if mapped.load(Ordering::Acquire) {
+            break;
         }
+    }
 
-        // Read results
-        let data = buffer_slice.get_mapped_range();
-        let result_u32s: &[u32] = bytemuck::cast_slice(&data);
+    // Read results
+    let data = buffer_slice.get_mapped_range();
+    let result_u32s: &[u32] = bytemuck::cast_slice(&data);
 
-        // Calculate the actual number of nonces dispatched
-        let dispatched_nonces = (total_threads * nonces_per_thread as u64).min(batch_size);
+    // Calculate the actual number of nonces dispatched
+    let dispatched_nonces = (total_threads * nonces_per_thread as u64).min(batch_size);
 
-        if result_u32s[0] != 0 {
-            // Solution found!
-            let nonce_u32s = &result_u32s[1..17];
-            let hash_u32s = &result_u32s[17..33];
-            let nonce = U512::from_little_endian(bytemuck::cast_slice(nonce_u32s));
-            let hash = U512::from_little_endian(bytemuck::cast_slice(hash_u32s));
-            let work = nonce.to_big_endian();
+    if result_u32s[0] != 0 {
+        // Solution found!
+        let nonce_u32s = &result_u32s[1..17];
+        let hash_u32s = &result_u32s[17..33];
+        let nonce = U512::from_little_endian(bytemuck::cast_slice(nonce_u32s));
+        let hash = U512::from_little_endian(bytemuck::cast_slice(hash_u32s));
+        let work = nonce.to_big_endian();
 
-            // Calculate hashes computed based on GPU parallel execution model
-            let hashes_computed = if nonce >= batch_start {
-                let logical_index = (nonce - batch_start).as_u64();
-                let winning_iteration = logical_index % (nonces_per_thread as u64);
-                (total_threads * (winning_iteration + 1)).min(dispatched_nonces)
-            } else {
-                dispatched_nonces
-            };
-
-            drop(data);
-            resources.staging_buffer.unmap();
-
-            return BatchResult::Found {
-                candidate: Candidate { nonce, work, hash },
-                hash_count: hashes_computed,
-            };
-        }
+        // Calculate hashes computed based on GPU parallel execution model
+        let hashes_computed = if nonce >= batch_start {
+            let logical_index = (nonce - batch_start).as_u64();
+            let winning_iteration = logical_index % (nonces_per_thread as u64);
+            (total_threads * (winning_iteration + 1)).min(dispatched_nonces)
+        } else {
+            dispatched_nonces
+        };
 
         drop(data);
         resources.staging_buffer.unmap();
 
-        BatchResult::NotFound {
-            hash_count: dispatched_nonces,
-        }
+        return BatchResult::Found {
+            candidate: Candidate { nonce, work, hash },
+            hash_count: hashes_computed,
+        };
     }
 
-    /// Get vendor-specific optimal dispatch configuration
-    fn get_vendor_specific_dispatch(
-        adapter_info: &wgpu::AdapterInfo,
-        device: &wgpu::Device,
-    ) -> u32 {
-        let limits = device.limits();
-        let max_workgroups = limits.max_compute_workgroups_per_dimension.min(65535);
+    drop(data);
+    resources.staging_buffer.unmap();
 
-        // Parse vendor from adapter info
-        let vendor_name = adapter_info.name.to_lowercase();
-        let _device_name = adapter_info.device.to_string().to_lowercase();
+    BatchResult::NotFound {
+        hash_count: dispatched_nonces,
+    }
+}
 
-        // Vendor-specific heuristics based on architecture knowledge
-        // Returns (workgroups, tier_name, is_fallback)
-        let (optimal_workgroups, tier, is_fallback) =
-            if vendor_name.contains("nvidia") || adapter_info.vendor == 4318 {
-                // NVIDIA GPUs (vendor ID 0x10DE = 4318)
-                if vendor_name.contains("5090") || vendor_name.contains("5080") {
-                    (
-                        (max_workgroups / 6).max(5120),
-                        "NVIDIA RTX 50 Flagship (Blackwell)",
-                        false,
-                    )
-                } else if vendor_name.contains("5070")
-                    || vendor_name.contains("5060")
-                    || vendor_name.contains("rtx 50")
-                {
-                    (
-                        (max_workgroups / 7).max(4608),
-                        "NVIDIA RTX 50 (Blackwell)",
-                        false,
-                    )
-                } else if vendor_name.contains("4090") || vendor_name.contains("4080") {
-                    (
-                        (max_workgroups / 8).max(4096),
-                        "NVIDIA RTX 40 Flagship (Ada)",
-                        false,
-                    )
-                } else if vendor_name.contains("rtx 40")
-                    || vendor_name.contains("4070")
-                    || vendor_name.contains("4060")
-                {
-                    (
-                        (max_workgroups / 10).max(3072),
-                        "NVIDIA RTX 40 (Ada)",
-                        false,
-                    )
-                } else if vendor_name.contains("rtx 30")
-                    || vendor_name.contains("rtx 20")
-                    || vendor_name.contains("3090")
-                    || vendor_name.contains("3080")
-                    || vendor_name.contains("3070")
-                    || vendor_name.contains("2080")
-                    || vendor_name.contains("2070")
-                    || vendor_name.contains("2060")
-                {
-                    (
-                        (max_workgroups / 12).max(2048),
-                        "NVIDIA RTX 30/20 (Ampere/Turing)",
-                        false,
-                    )
-                } else if vendor_name.contains("gtx 16")
-                    || vendor_name.contains("gtx 10")
-                    || vendor_name.contains("1660")
-                    || vendor_name.contains("1650")
-                    || vendor_name.contains("1080")
-                    || vendor_name.contains("1070")
-                    || vendor_name.contains("1060")
-                {
-                    (
-                        (max_workgroups / 16).max(1024),
-                        "NVIDIA GTX 16/10 (Turing/Pascal)",
-                        false,
-                    )
-                } else if vendor_name.contains("gtx") {
-                    ((max_workgroups / 18).max(768), "NVIDIA GTX (Legacy)", false)
-                } else if vendor_name.contains("quadro")
-                    || vendor_name.contains("rtx a")
-                    || vendor_name.contains("tesla")
-                {
-                    (
-                        (max_workgroups / 10).max(2560),
-                        "NVIDIA Quadro/Professional",
-                        false,
-                    )
-                } else {
-                    ((max_workgroups / 20).max(512), "NVIDIA Unknown", true)
-                }
-            } else if vendor_name.contains("amd")
-                || vendor_name.contains("radeon")
-                || adapter_info.vendor == 4098
+/// Get vendor-specific optimal dispatch configuration
+fn get_vendor_specific_dispatch(adapter_info: &wgpu::AdapterInfo, device: &wgpu::Device) -> u32 {
+    let limits = device.limits();
+    let max_workgroups = limits.max_compute_workgroups_per_dimension.min(65535);
+
+    // Parse vendor from adapter info
+    let vendor_name = adapter_info.name.to_lowercase();
+    let _device_name = adapter_info.device.to_string().to_lowercase();
+
+    // Vendor-specific heuristics based on architecture knowledge
+    // Returns (workgroups, tier_name, is_fallback)
+    let (optimal_workgroups, tier, is_fallback) =
+        if vendor_name.contains("nvidia") || adapter_info.vendor == 4318 {
+            // NVIDIA GPUs (vendor ID 0x10DE = 4318)
+            if vendor_name.contains("5090") || vendor_name.contains("5080") {
+                (
+                    (max_workgroups / 6).max(5120),
+                    "NVIDIA RTX 50 Flagship (Blackwell)",
+                    false,
+                )
+            } else if vendor_name.contains("5070")
+                || vendor_name.contains("5060")
+                || vendor_name.contains("rtx 50")
             {
-                // AMD GPUs (vendor ID 0x1002 = 4098)
-                if vendor_name.contains("rx 9")
-                    || vendor_name.contains("9070")
-                    || vendor_name.contains("9080")
-                {
-                    (
-                        (max_workgroups / 8).max(4096),
-                        "AMD RX 9000 (RDNA 4)",
-                        false,
-                    )
-                } else if vendor_name.contains("7900") {
-                    (
-                        (max_workgroups / 9).max(3584),
-                        "AMD RX 7900 (RDNA 3 Flagship)",
-                        false,
-                    )
-                } else if vendor_name.contains("rx 7")
-                    || vendor_name.contains("7800")
-                    || vendor_name.contains("7700")
-                    || vendor_name.contains("7600")
-                {
-                    (
-                        (max_workgroups / 10).max(3072),
-                        "AMD RX 7000 (RDNA 3)",
-                        false,
-                    )
-                } else if vendor_name.contains("6900") || vendor_name.contains("6800") {
-                    (
-                        (max_workgroups / 12).max(2560),
-                        "AMD RX 6900/6800 (RDNA 2 Flagship)",
-                        false,
-                    )
-                } else if vendor_name.contains("rx 6")
-                    || vendor_name.contains("6700")
-                    || vendor_name.contains("6600")
-                {
-                    (
-                        (max_workgroups / 14).max(2048),
-                        "AMD RX 6000 (RDNA 2)",
-                        false,
-                    )
-                } else if vendor_name.contains("5700") {
-                    (
-                        (max_workgroups / 16).max(1536),
-                        "AMD RX 5700 (RDNA 1)",
-                        false,
-                    )
-                } else if vendor_name.contains("rx 5")
-                    || vendor_name.contains("5600")
-                    || vendor_name.contains("5500")
-                {
-                    (
-                        (max_workgroups / 18).max(1024),
-                        "AMD RX 5000 (RDNA 1)",
-                        false,
-                    )
-                } else if vendor_name.contains("rx 4")
-                    || vendor_name.contains("580")
-                    || vendor_name.contains("570")
-                {
-                    (
-                        (max_workgroups / 20).max(768),
-                        "AMD RX 500/400 (Polaris)",
-                        false,
-                    )
-                } else if vendor_name.contains("radeon pro")
-                    || vendor_name.contains("instinct")
-                    || vendor_name.contains("mi")
-                {
-                    (
-                        (max_workgroups / 10).max(2560),
-                        "AMD Radeon Pro/Instinct",
-                        false,
-                    )
-                } else {
-                    ((max_workgroups / 24).max(512), "AMD Unknown", true)
-                }
-            } else if vendor_name.contains("intel") || adapter_info.vendor == 32902 {
-                // Intel GPUs (vendor ID 0x8086 = 32902)
-                if vendor_name.contains("arc b")
-                    || vendor_name.contains("b580")
-                    || vendor_name.contains("b570")
-                {
-                    (
-                        (max_workgroups / 10).max(2560),
-                        "Intel Arc B-Series (Battlemage)",
-                        false,
-                    )
-                } else if vendor_name.contains("a770") || vendor_name.contains("a750") {
-                    (
-                        (max_workgroups / 12).max(2048),
-                        "Intel Arc A7 (Alchemist)",
-                        false,
-                    )
-                } else if vendor_name.contains("a580")
-                    || vendor_name.contains("a380")
-                    || vendor_name.contains("arc a5")
-                    || vendor_name.contains("arc a3")
-                {
-                    (
-                        (max_workgroups / 16).max(1024),
-                        "Intel Arc A5/A3 (Alchemist)",
-                        false,
-                    )
-                } else if vendor_name.contains("a310") {
-                    ((max_workgroups / 20).max(512), "Intel Arc A3 Entry", false)
-                } else if vendor_name.contains("iris xe") || vendor_name.contains("iris plus") {
-                    (
-                        (max_workgroups / 24).max(384),
-                        "Intel Iris Xe/Plus (Integrated)",
-                        false,
-                    )
-                } else if vendor_name.contains("uhd") || vendor_name.contains("hd graphics") {
-                    (
-                        (max_workgroups / 28).max(256),
-                        "Intel UHD/HD Graphics (Integrated)",
-                        false,
-                    )
-                } else {
-                    ((max_workgroups / 24).max(256), "Intel Unknown", true)
-                }
-            } else if adapter_info.backend == wgpu::Backend::Metal {
-                // Apple GPUs (detected by Metal backend)
-                let (gpu_cores, workgroups, tier) = if vendor_name.contains("m4 ultra") {
-                    (80, 1600, "Apple M4 Ultra")
-                } else if vendor_name.contains("m4 max") {
-                    (40, 800, "Apple M4 Max")
-                } else if vendor_name.contains("m4 pro") {
-                    (20, 400, "Apple M4 Pro")
-                } else if vendor_name.contains("m4") {
-                    (10, 200, "Apple M4")
-                } else if vendor_name.contains("m3 ultra") {
-                    (76, 1520, "Apple M3 Ultra")
-                } else if vendor_name.contains("m3 max") {
-                    (40, 800, "Apple M3 Max")
-                } else if vendor_name.contains("m3 pro") {
-                    (18, 360, "Apple M3 Pro")
-                } else if vendor_name.contains("m3") {
-                    (10, 200, "Apple M3")
-                } else if vendor_name.contains("m2 ultra") {
-                    (76, 1520, "Apple M2 Ultra")
-                } else if vendor_name.contains("m2 max") {
-                    (38, 760, "Apple M2 Max")
-                } else if vendor_name.contains("m2 pro") {
-                    (19, 380, "Apple M2 Pro")
-                } else if vendor_name.contains("m2") {
-                    (10, 200, "Apple M2")
-                } else if vendor_name.contains("m1 ultra") {
-                    (64, 1280, "Apple M1 Ultra")
-                } else if vendor_name.contains("m1 max") {
-                    (32, 640, "Apple M1 Max")
-                } else if vendor_name.contains("m1 pro") {
-                    (16, 320, "Apple M1 Pro")
-                } else if vendor_name.contains("m1") {
-                    (8, 160, "Apple M1")
-                } else {
-                    (8, 160, "Apple Silicon Unknown")
-                };
-
-                let clamped_workgroups = workgroups.min(max_workgroups / 4).max(64);
-                let _ = gpu_cores; // gpu_cores currently unused but kept for potential future tuning
-                let is_fallback = tier == "Apple Silicon Unknown";
-                (clamped_workgroups, tier, is_fallback)
+                (
+                    (max_workgroups / 7).max(4608),
+                    "NVIDIA RTX 50 (Blackwell)",
+                    false,
+                )
+            } else if vendor_name.contains("4090") || vendor_name.contains("4080") {
+                (
+                    (max_workgroups / 8).max(4096),
+                    "NVIDIA RTX 40 Flagship (Ada)",
+                    false,
+                )
+            } else if vendor_name.contains("rtx 40")
+                || vendor_name.contains("4070")
+                || vendor_name.contains("4060")
+            {
+                (
+                    (max_workgroups / 10).max(3072),
+                    "NVIDIA RTX 40 (Ada)",
+                    false,
+                )
+            } else if vendor_name.contains("rtx 30")
+                || vendor_name.contains("rtx 20")
+                || vendor_name.contains("3090")
+                || vendor_name.contains("3080")
+                || vendor_name.contains("3070")
+                || vendor_name.contains("2080")
+                || vendor_name.contains("2070")
+                || vendor_name.contains("2060")
+            {
+                (
+                    (max_workgroups / 12).max(2048),
+                    "NVIDIA RTX 30/20 (Ampere/Turing)",
+                    false,
+                )
+            } else if vendor_name.contains("gtx 16")
+                || vendor_name.contains("gtx 10")
+                || vendor_name.contains("1660")
+                || vendor_name.contains("1650")
+                || vendor_name.contains("1080")
+                || vendor_name.contains("1070")
+                || vendor_name.contains("1060")
+            {
+                (
+                    (max_workgroups / 16).max(1024),
+                    "NVIDIA GTX 16/10 (Turing/Pascal)",
+                    false,
+                )
+            } else if vendor_name.contains("gtx") {
+                ((max_workgroups / 18).max(768), "NVIDIA GTX (Legacy)", false)
+            } else if vendor_name.contains("quadro")
+                || vendor_name.contains("rtx a")
+                || vendor_name.contains("tesla")
+            {
+                (
+                    (max_workgroups / 10).max(2560),
+                    "NVIDIA Quadro/Professional",
+                    false,
+                )
             } else {
-                // Unknown/Generic GPU - use conservative defaults
-                ((max_workgroups / 16).max(512), "Unknown GPU", true)
+                ((max_workgroups / 20).max(512), "NVIDIA Unknown", true)
+            }
+        } else if vendor_name.contains("amd")
+            || vendor_name.contains("radeon")
+            || adapter_info.vendor == 4098
+        {
+            // AMD GPUs (vendor ID 0x1002 = 4098)
+            if vendor_name.contains("rx 9")
+                || vendor_name.contains("9070")
+                || vendor_name.contains("9080")
+            {
+                (
+                    (max_workgroups / 8).max(4096),
+                    "AMD RX 9000 (RDNA 4)",
+                    false,
+                )
+            } else if vendor_name.contains("7900") {
+                (
+                    (max_workgroups / 9).max(3584),
+                    "AMD RX 7900 (RDNA 3 Flagship)",
+                    false,
+                )
+            } else if vendor_name.contains("rx 7")
+                || vendor_name.contains("7800")
+                || vendor_name.contains("7700")
+                || vendor_name.contains("7600")
+            {
+                (
+                    (max_workgroups / 10).max(3072),
+                    "AMD RX 7000 (RDNA 3)",
+                    false,
+                )
+            } else if vendor_name.contains("6900") || vendor_name.contains("6800") {
+                (
+                    (max_workgroups / 12).max(2560),
+                    "AMD RX 6900/6800 (RDNA 2 Flagship)",
+                    false,
+                )
+            } else if vendor_name.contains("rx 6")
+                || vendor_name.contains("6700")
+                || vendor_name.contains("6600")
+            {
+                (
+                    (max_workgroups / 14).max(2048),
+                    "AMD RX 6000 (RDNA 2)",
+                    false,
+                )
+            } else if vendor_name.contains("5700") {
+                (
+                    (max_workgroups / 16).max(1536),
+                    "AMD RX 5700 (RDNA 1)",
+                    false,
+                )
+            } else if vendor_name.contains("rx 5")
+                || vendor_name.contains("5600")
+                || vendor_name.contains("5500")
+            {
+                (
+                    (max_workgroups / 18).max(1024),
+                    "AMD RX 5000 (RDNA 1)",
+                    false,
+                )
+            } else if vendor_name.contains("rx 4")
+                || vendor_name.contains("580")
+                || vendor_name.contains("570")
+            {
+                (
+                    (max_workgroups / 20).max(768),
+                    "AMD RX 500/400 (Polaris)",
+                    false,
+                )
+            } else if vendor_name.contains("radeon pro")
+                || vendor_name.contains("instinct")
+                || vendor_name.contains("mi")
+            {
+                (
+                    (max_workgroups / 10).max(2560),
+                    "AMD Radeon Pro/Instinct",
+                    false,
+                )
+            } else {
+                ((max_workgroups / 24).max(512), "AMD Unknown", true)
+            }
+        } else if vendor_name.contains("intel") || adapter_info.vendor == 32902 {
+            // Intel GPUs (vendor ID 0x8086 = 32902)
+            if vendor_name.contains("arc b")
+                || vendor_name.contains("b580")
+                || vendor_name.contains("b570")
+            {
+                (
+                    (max_workgroups / 10).max(2560),
+                    "Intel Arc B-Series (Battlemage)",
+                    false,
+                )
+            } else if vendor_name.contains("a770") || vendor_name.contains("a750") {
+                (
+                    (max_workgroups / 12).max(2048),
+                    "Intel Arc A7 (Alchemist)",
+                    false,
+                )
+            } else if vendor_name.contains("a580")
+                || vendor_name.contains("a380")
+                || vendor_name.contains("arc a5")
+                || vendor_name.contains("arc a3")
+            {
+                (
+                    (max_workgroups / 16).max(1024),
+                    "Intel Arc A5/A3 (Alchemist)",
+                    false,
+                )
+            } else if vendor_name.contains("a310") {
+                ((max_workgroups / 20).max(512), "Intel Arc A3 Entry", false)
+            } else if vendor_name.contains("iris xe") || vendor_name.contains("iris plus") {
+                (
+                    (max_workgroups / 24).max(384),
+                    "Intel Iris Xe/Plus (Integrated)",
+                    false,
+                )
+            } else if vendor_name.contains("uhd") || vendor_name.contains("hd graphics") {
+                (
+                    (max_workgroups / 28).max(256),
+                    "Intel UHD/HD Graphics (Integrated)",
+                    false,
+                )
+            } else {
+                ((max_workgroups / 24).max(256), "Intel Unknown", true)
+            }
+        } else if adapter_info.backend == wgpu::Backend::Metal {
+            // Apple GPUs (detected by Metal backend)
+            let (gpu_cores, workgroups, tier) = if vendor_name.contains("m4 ultra") {
+                (80, 1600, "Apple M4 Ultra")
+            } else if vendor_name.contains("m4 max") {
+                (40, 800, "Apple M4 Max")
+            } else if vendor_name.contains("m4 pro") {
+                (20, 400, "Apple M4 Pro")
+            } else if vendor_name.contains("m4") {
+                (10, 200, "Apple M4")
+            } else if vendor_name.contains("m3 ultra") {
+                (76, 1520, "Apple M3 Ultra")
+            } else if vendor_name.contains("m3 max") {
+                (40, 800, "Apple M3 Max")
+            } else if vendor_name.contains("m3 pro") {
+                (18, 360, "Apple M3 Pro")
+            } else if vendor_name.contains("m3") {
+                (10, 200, "Apple M3")
+            } else if vendor_name.contains("m2 ultra") {
+                (76, 1520, "Apple M2 Ultra")
+            } else if vendor_name.contains("m2 max") {
+                (38, 760, "Apple M2 Max")
+            } else if vendor_name.contains("m2 pro") {
+                (19, 380, "Apple M2 Pro")
+            } else if vendor_name.contains("m2") {
+                (10, 200, "Apple M2")
+            } else if vendor_name.contains("m1 ultra") {
+                (64, 1280, "Apple M1 Ultra")
+            } else if vendor_name.contains("m1 max") {
+                (32, 640, "Apple M1 Max")
+            } else if vendor_name.contains("m1 pro") {
+                (16, 320, "Apple M1 Pro")
+            } else if vendor_name.contains("m1") {
+                (8, 160, "Apple M1")
+            } else {
+                (8, 160, "Apple Silicon Unknown")
             };
 
-        // Log GPU detection result
-        log::info!(
+            let clamped_workgroups = workgroups.min(max_workgroups / 4).max(64);
+            let _ = gpu_cores; // gpu_cores currently unused but kept for potential future tuning
+            let is_fallback = tier == "Apple Silicon Unknown";
+            (clamped_workgroups, tier, is_fallback)
+        } else {
+            // Unknown/Generic GPU - use conservative defaults
+            ((max_workgroups / 16).max(512), "Unknown GPU", true)
+        };
+
+    // Log GPU detection result
+    log::info!(
+        target: "gpu_engine",
+        "GPU detected: {} | tier: {} | workgroups: {} (max: {})",
+        adapter_info.name,
+        tier,
+        optimal_workgroups,
+        max_workgroups
+    );
+
+    if is_fallback {
+        log::warn!(
             target: "gpu_engine",
-            "GPU detected: {} | tier: {} | workgroups: {} (max: {})",
+            "GPU not recognized, using fallback config. Please report: name='{}', vendor=0x{:04X}, device={}",
             adapter_info.name,
-            tier,
-            optimal_workgroups,
-            max_workgroups
+            adapter_info.vendor,
+            adapter_info.device
         );
-
-        if is_fallback {
-            log::warn!(
-                target: "gpu_engine",
-                "GPU not recognized, using fallback config. Please report: name='{}', vendor=0x{:04X}, device={}",
-                adapter_info.name,
-                adapter_info.vendor,
-                adapter_info.device
-            );
-            log::warn!(target: "gpu_engine", "Report at: https://github.com/Quantus-Network/quantus-miner/issues");
-        }
-
-        optimal_workgroups
+        log::warn!(target: "gpu_engine", "Report at: https://github.com/Quantus-Network/quantus-miner/issues");
     }
+
+    optimal_workgroups
 }

--- a/crates/engine-gpu/src/mining.wgsl
+++ b/crates/engine-gpu/src/mining.wgsl
@@ -194,8 +194,7 @@ const MDS_MATRIX_DIAG_12: array<array<u32, 2>, 12> = array<array<u32, 2>, 12>(
 @group(0) @binding(1) var<storage, read> header: array<u32, 8>;     // 32 bytes
 @group(0) @binding(2) var<storage, read> start_nonce: array<u32, 16>; // 64 bytes
 @group(0) @binding(3) var<storage, read> difficulty_target: array<u32, 16>;    // 64 bytes (U512 target)
-@group(0) @binding(4) var<storage, read> dispatch_config: array<u32, 4>; // [total_threads, nonces_per_thread, total_nonces, cancel_check_interval]
-@group(0) @binding(5) var<storage, read> cancel_flag: array<u32, 1>; // 0 = running, 1 = cancel requested
+@group(0) @binding(4) var<storage, read> dispatch_config: array<u32, 3>; // [total_threads, nonces_per_thread, total_nonces]
 
 // Goldilocks field element represented as [limb0, limb1]
 // where the value is limb0 + limb1*2^32
@@ -804,11 +803,8 @@ fn is_below_target(hash: array<u32, 16>, difficulty_tgt: array<u32, 16>) -> bool
 // Main mining kernel
 @compute @workgroup_size(256)
 fn mining_main(@builtin(global_invocation_id) global_id: vec3<u32>) {
-    // If solution already found or cancelled, exit early
+    // If solution already found, exit early
     if (atomicLoad(&results[0]) != 0u) {
-        return;
-    }
-    if (cancel_flag[0] != 0u) {
         return;
     }
 
@@ -817,7 +813,6 @@ fn mining_main(@builtin(global_invocation_id) global_id: vec3<u32>) {
     let total_threads = dispatch_config[0];        // Total logical threads in this dispatch
     let nonces_per_thread = dispatch_config[1];    // Nonces processed by each thread
     let total_nonces = dispatch_config[2];         // Total logical nonces this dispatch should cover
-    let cancel_check_interval = dispatch_config[3]; // How often to check cancel flag
 
     // Guard against threads beyond configured total_threads
     if (thread_id >= total_threads) {
@@ -832,14 +827,6 @@ fn mining_main(@builtin(global_invocation_id) global_id: vec3<u32>) {
         let logical_index = base_index + j;
         if (logical_index >= total_nonces) {
             break;
-        }
-
-        // Periodic checks for early exit
-        // Check cancel flag every cancel_check_interval iterations
-        if (cancel_check_interval > 0u && (j % cancel_check_interval) == 0u) {
-            if (cancel_flag[0] != 0u) {
-                return;
-            }
         }
 
         // Check if solution already found (early exit for entire dispatch)

--- a/crates/miner-cli/src/main.rs
+++ b/crates/miner-cli/src/main.rs
@@ -8,6 +8,10 @@ use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant};
 
+// CLI defaults
+const DEFAULT_GPU_BATCH_SIZE: u64 = 1_000_000;
+const DEFAULT_CPU_BATCH_SIZE: u64 = 10_000;
+
 #[derive(Subcommand, Debug)]
 enum Command {
     /// Run the mining service
@@ -24,9 +28,13 @@ enum Command {
         #[arg(long = "gpu-devices", env = "MINER_GPU_DEVICES")]
         gpu_devices: Option<usize>,
 
-        /// GPU batch size in nonces - controls how often GPU checks for cancellation (default: 10000000)
-        #[arg(long = "gpu-batch-size", env = "MINER_GPU_BATCH_SIZE")]
-        gpu_batch_size: Option<u64>,
+        /// GPU batch size in nonces - controls how often GPU checks for cancellation
+        #[arg(long = "gpu-batch-size", env = "MINER_GPU_BATCH_SIZE", default_value_t = DEFAULT_GPU_BATCH_SIZE)]
+        gpu_batch_size: u64,
+
+        /// CPU batch size in hashes - controls how often CPU checks for cancellation
+        #[arg(long = "cpu-batch-size", env = "MINER_CPU_BATCH_SIZE", default_value_t = DEFAULT_CPU_BATCH_SIZE)]
+        cpu_batch_size: u64,
 
         /// Port for Prometheus metrics HTTP endpoint (default: 9900)
         #[arg(
@@ -85,6 +93,7 @@ async fn main() {
             cpu_workers,
             gpu_devices,
             gpu_batch_size,
+            cpu_batch_size,
             metrics_port,
             verbose,
         } => {
@@ -107,6 +116,7 @@ async fn main() {
                 cpu_workers,
                 gpu_devices,
                 gpu_batch_size,
+                cpu_batch_size,
             };
 
             if let Err(e) = run(config).await {
@@ -142,9 +152,9 @@ fn init_logger(verbose: bool) {
 async fn run_benchmark(cpu_workers: Option<usize>, gpu_devices: Option<usize>, duration: u64) {
     let effective_cpu_workers = cpu_workers.unwrap_or_else(num_cpus::get);
 
-    // Initialize GPU engine
+    // Initialize GPU engine (use default batch sizes for benchmark)
     let (gpu_engine, effective_gpu_devices) =
-        match miner_service::resolve_gpu_configuration(gpu_devices, None) {
+        match miner_service::resolve_gpu_configuration(gpu_devices, DEFAULT_GPU_BATCH_SIZE) {
             Ok((engine, count)) => (engine, count),
             Err(e) => {
                 eprintln!("❌ ERROR: {}", e);
@@ -172,7 +182,7 @@ async fn run_benchmark(cpu_workers: Option<usize>, gpu_devices: Option<usize>, d
 
     // Create CPU engine
     let cpu_engine: Option<Arc<dyn MinerEngine>> = if effective_cpu_workers > 0 {
-        Some(Arc::new(engine_cpu::FastCpuEngine::new()))
+        Some(Arc::new(engine_cpu::FastCpuEngine::new(DEFAULT_CPU_BATCH_SIZE)))
     } else {
         None
     };

--- a/crates/miner-cli/src/main.rs
+++ b/crates/miner-cli/src/main.rs
@@ -1,5 +1,5 @@
 use clap::{Parser, Subcommand};
-use engine_cpu::{EngineRange, MinerEngine};
+use engine_cpu::{AtomicBoolCancelCheck, EngineRange, MinerEngine};
 use miner_service::{run, ServiceConfig};
 use primitive_types::U512;
 use rand::RngCore;
@@ -24,9 +24,9 @@ enum Command {
         #[arg(long = "gpu-devices", env = "MINER_GPU_DEVICES")]
         gpu_devices: Option<usize>,
 
-        /// GPU cancel check interval in nonces (default: 10000)
-        #[arg(long = "gpu-cancel-interval", env = "MINER_GPU_CANCEL_INTERVAL")]
-        gpu_cancel_interval: Option<u32>,
+        /// GPU batch size in nonces - controls how often GPU checks for cancellation (default: 10000000)
+        #[arg(long = "gpu-batch-size", env = "MINER_GPU_BATCH_SIZE")]
+        gpu_batch_size: Option<u64>,
 
         /// Port for Prometheus metrics HTTP endpoint (default: 9900)
         #[arg(
@@ -84,7 +84,7 @@ async fn main() {
             node_addr,
             cpu_workers,
             gpu_devices,
-            gpu_cancel_interval,
+            gpu_batch_size,
             metrics_port,
             verbose,
         } => {
@@ -106,7 +106,7 @@ async fn main() {
                 node_addr,
                 cpu_workers,
                 gpu_devices,
-                gpu_cancel_interval,
+                gpu_batch_size,
             };
 
             if let Err(e) = run(config).await {
@@ -224,7 +224,8 @@ async fn run_benchmark(cpu_workers: Option<usize>, gpu_devices: Option<usize>, d
                     break;
                 }
 
-                let result = engine.search_range(&ctx, worker_range.clone(), &cancel);
+                let cancel_check = AtomicBoolCancelCheck(&cancel);
+                let result = engine.search_range(&ctx, worker_range.clone(), &cancel_check);
 
                 match result {
                     engine_cpu::EngineStatus::Found { hash_count, .. }

--- a/crates/miner-cli/src/main.rs
+++ b/crates/miner-cli/src/main.rs
@@ -59,6 +59,14 @@ enum Command {
         #[arg(long = "gpu-devices", env = "MINER_GPU_DEVICES")]
         gpu_devices: Option<usize>,
 
+        /// GPU batch size in nonces - controls how often GPU checks for cancellation
+        #[arg(long = "gpu-batch-size", env = "MINER_GPU_BATCH_SIZE", default_value_t = DEFAULT_GPU_BATCH_SIZE)]
+        gpu_batch_size: u64,
+
+        /// CPU batch size in hashes - controls how often CPU checks for cancellation
+        #[arg(long = "cpu-batch-size", env = "MINER_CPU_BATCH_SIZE", default_value_t = DEFAULT_CPU_BATCH_SIZE)]
+        cpu_batch_size: u64,
+
         /// Benchmark duration in seconds (default: 10)
         #[arg(short, long, default_value_t = 10)]
         duration: u64,
@@ -128,11 +136,20 @@ async fn main() {
         Command::Benchmark {
             cpu_workers,
             gpu_devices,
+            gpu_batch_size,
+            cpu_batch_size,
             duration,
             verbose,
         } => {
             init_logger(verbose);
-            run_benchmark(cpu_workers, gpu_devices, duration).await;
+            run_benchmark(
+                cpu_workers,
+                gpu_devices,
+                gpu_batch_size,
+                cpu_batch_size,
+                duration,
+            )
+            .await;
         }
     }
 }
@@ -149,12 +166,18 @@ fn init_logger(verbose: bool) {
     env_logger::init();
 }
 
-async fn run_benchmark(cpu_workers: Option<usize>, gpu_devices: Option<usize>, duration: u64) {
+async fn run_benchmark(
+    cpu_workers: Option<usize>,
+    gpu_devices: Option<usize>,
+    gpu_batch_size: u64,
+    cpu_batch_size: u64,
+    duration: u64,
+) {
     let effective_cpu_workers = cpu_workers.unwrap_or_else(num_cpus::get);
 
-    // Initialize GPU engine (use default batch sizes for benchmark)
+    // Initialize GPU engine
     let (gpu_engine, effective_gpu_devices) =
-        match miner_service::resolve_gpu_configuration(gpu_devices, DEFAULT_GPU_BATCH_SIZE) {
+        match miner_service::resolve_gpu_configuration(gpu_devices, gpu_batch_size) {
             Ok((engine, count)) => (engine, count),
             Err(e) => {
                 eprintln!("❌ ERROR: {}", e);
@@ -182,9 +205,7 @@ async fn run_benchmark(cpu_workers: Option<usize>, gpu_devices: Option<usize>, d
 
     // Create CPU engine
     let cpu_engine: Option<Arc<dyn MinerEngine>> = if effective_cpu_workers > 0 {
-        Some(Arc::new(engine_cpu::FastCpuEngine::new(
-            DEFAULT_CPU_BATCH_SIZE,
-        )))
+        Some(Arc::new(engine_cpu::FastCpuEngine::new(cpu_batch_size)))
     } else {
         None
     };

--- a/crates/miner-cli/src/main.rs
+++ b/crates/miner-cli/src/main.rs
@@ -182,7 +182,9 @@ async fn run_benchmark(cpu_workers: Option<usize>, gpu_devices: Option<usize>, d
 
     // Create CPU engine
     let cpu_engine: Option<Arc<dyn MinerEngine>> = if effective_cpu_workers > 0 {
-        Some(Arc::new(engine_cpu::FastCpuEngine::new(DEFAULT_CPU_BATCH_SIZE)))
+        Some(Arc::new(engine_cpu::FastCpuEngine::new(
+            DEFAULT_CPU_BATCH_SIZE,
+        )))
     } else {
         None
     };

--- a/crates/miner-service/src/lib.rs
+++ b/crates/miner-service/src/lib.rs
@@ -200,17 +200,18 @@ impl WorkerPool {
             let _ = tx.send(job.clone());
         }
 
-        log::debug!(
-            "[JOB DISPATCH] Job {} dispatched to {} workers",
-            new_job_id,
-            self.job_senders.len()
-        );
+        let worker_count = self.job_senders.len();
+        log::debug!("[JOB DISPATCH] Job {new_job_id} dispatched to {worker_count} workers");
 
         new_job_id
     }
 
     /// Cancel the current job by incrementing the job ID.
     /// Workers will detect the change and stop processing.
+    ///
+    /// Note: This increments job_id by 1, and start_job() also increments by 1,
+    /// so job IDs in logs may become non-contiguous after disconnects/cancellations.
+    /// This is expected behavior - job IDs only need to be unique, not sequential.
     pub fn cancel(&self) {
         self.current_job_id.fetch_add(1, Ordering::SeqCst);
     }
@@ -234,6 +235,26 @@ impl WorkerPool {
     pub fn gpu_worker_count(&self) -> usize {
         self.gpu_worker_count
     }
+}
+
+/// Log worker completion with hash rate info.
+fn log_worker_completion(
+    type_str: &str,
+    thread_id: usize,
+    status: &str,
+    hash_count: u64,
+    elapsed: std::time::Duration,
+) {
+    let hash_rate = if elapsed.as_secs_f64() > 0.0 {
+        hash_count as f64 / elapsed.as_secs_f64()
+    } else {
+        0.0
+    };
+    log::info!(
+        "{type_str} worker {thread_id} {status}: {hash_count} hashes in {:.2}s ({})",
+        elapsed.as_secs_f64(),
+        format_hashrate(hash_rate)
+    );
 }
 
 /// Main loop for a persistent worker thread.
@@ -318,15 +339,12 @@ fn worker_loop(
                 engine_cpu::EngineStatus::Cancelled { hash_count } => hash_count,
                 engine_cpu::EngineStatus::Running { .. } => 0,
             };
-            let hash_rate = if search_elapsed.as_secs_f64() > 0.0 {
-                hash_count as f64 / search_elapsed.as_secs_f64()
-            } else {
-                0.0
-            };
-            log::info!(
-                "{type_str} worker {thread_id} cancelled (stale): {hash_count} hashes in {:.2}s ({})",
-                search_elapsed.as_secs_f64(),
-                format_hashrate(hash_rate)
+            log_worker_completion(
+                type_str,
+                thread_id,
+                "cancelled (stale)",
+                hash_count,
+                search_elapsed,
             );
             let _ = result_tx.try_send(WorkerResult {
                 thread_id,
@@ -354,25 +372,17 @@ fn worker_loop(
                 (Some(MiningCandidate { nonce, work, hash }), hash_count)
             }
             engine_cpu::EngineStatus::Exhausted { hash_count } => {
-                let hash_rate = hash_count as f64 / search_elapsed.as_secs_f64();
-                log::info!(
-                    "{type_str} worker {thread_id} exhausted range: {hash_count} hashes in {:.2}s ({})",
-                    search_elapsed.as_secs_f64(),
-                    format_hashrate(hash_rate)
+                log_worker_completion(
+                    type_str,
+                    thread_id,
+                    "exhausted range",
+                    hash_count,
+                    search_elapsed,
                 );
                 (None, hash_count)
             }
             engine_cpu::EngineStatus::Cancelled { hash_count } => {
-                let hash_rate = if search_elapsed.as_secs_f64() > 0.0 {
-                    hash_count as f64 / search_elapsed.as_secs_f64()
-                } else {
-                    0.0
-                };
-                log::info!(
-                    "{type_str} worker {thread_id} cancelled: {hash_count} hashes in {:.2}s ({})",
-                    search_elapsed.as_secs_f64(),
-                    format_hashrate(hash_rate)
-                );
+                log_worker_completion(type_str, thread_id, "cancelled", hash_count, search_elapsed);
                 (None, hash_count)
             }
             engine_cpu::EngineStatus::Running { .. } => {
@@ -418,7 +428,7 @@ pub fn resolve_gpu_configuration(
             if requested_devices.is_some() {
                 anyhow::bail!("Failed to initialize GPU engine: {}", e);
             }
-            log::info!("No GPU available: {}", e);
+            log::info!("No GPU available: {e}");
             return Ok((None, 0));
         }
     };
@@ -438,7 +448,7 @@ pub fn resolve_gpu_configuration(
             return Ok((None, 0));
         }
         None => {
-            log::info!("Auto-detected {} GPU device(s)", available);
+            log::info!("Auto-detected {available} GPU device(s)");
             available
         }
     };
@@ -488,19 +498,20 @@ pub async fn run(config: ServiceConfig) -> anyhow::Result<()> {
     );
 
     if let Some(ref engine) = cpu_engine {
-        log::info!("🖥️  CPU engine: {}", engine.name());
+        let name = engine.name();
+        log::info!("🖥️  CPU engine: {name}");
     }
     if let Some(ref engine) = gpu_engine {
-        log::info!("🎮 GPU engine: {}", engine.name());
+        let name = engine.name();
+        log::info!("🎮 GPU engine: {name}");
     }
 
-    log::info!(
-        "⛏️  Mining service ready with {} total workers",
-        cpu_workers + gpu_devices
-    );
+    let total_workers = cpu_workers + gpu_devices;
+    log::info!("⛏️  Mining service ready with {total_workers} total workers");
 
     // Connect to node and start mining
-    log::info!("🌐 Connecting to node at {}", config.node_addr);
+    let node_addr = config.node_addr;
+    log::info!("🌐 Connecting to node at {node_addr}");
     quic::connect_and_mine(
         config.node_addr,
         cpu_engine,

--- a/crates/miner-service/src/lib.rs
+++ b/crates/miner-service/src/lib.rs
@@ -12,7 +12,7 @@ pub mod quic;
 
 use crossbeam_channel::{bounded, unbounded, Receiver, Sender};
 use engine_cpu::{EngineCandidate, EngineRange, JobIdCancelCheck, MinerEngine};
-use pow_core::format_u512;
+use pow_core::{format_hashrate, format_u512};
 use primitive_types::U512;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
@@ -27,8 +27,10 @@ pub struct ServiceConfig {
     pub cpu_workers: Option<usize>,
     /// Number of GPU devices to use for mining (None = auto-detect)
     pub gpu_devices: Option<usize>,
-    /// GPU batch size in nonces (None = use default of 10,000,000)
-    pub gpu_batch_size: Option<u64>,
+    /// GPU batch size in nonces
+    pub gpu_batch_size: u64,
+    /// CPU batch size in hashes
+    pub cpu_batch_size: u64,
 }
 
 /// Engine type for tracking metrics per compute type.
@@ -36,17 +38,6 @@ pub struct ServiceConfig {
 pub enum EngineType {
     Cpu,
     Gpu,
-}
-
-impl Default for ServiceConfig {
-    fn default() -> Self {
-        Self {
-            node_addr: "127.0.0.1:9833".parse().unwrap(),
-            cpu_workers: None,
-            gpu_devices: None,
-            gpu_batch_size: None,
-        }
-    }
 }
 
 /// Result from a single worker thread.
@@ -334,9 +325,6 @@ fn worker_loop(
         // Check if job ID changed during search - if so, this result is stale
         let actual_job_id = current_job_id.load(Ordering::SeqCst);
         if actual_job_id != job_id {
-            log::debug!(
-                "⏰ {type_str} worker {thread_id} discarding stale result (job {job_id} != current {actual_job_id})"
-            );
             // Still send hash count for metrics, but without the candidate
             let hash_count = match result {
                 engine_cpu::EngineStatus::Found { hash_count, .. } => hash_count,
@@ -344,6 +332,16 @@ fn worker_loop(
                 engine_cpu::EngineStatus::Cancelled { hash_count } => hash_count,
                 engine_cpu::EngineStatus::Running { .. } => 0,
             };
+            let hash_rate = if search_elapsed.as_secs_f64() > 0.0 {
+                hash_count as f64 / search_elapsed.as_secs_f64()
+            } else {
+                0.0
+            };
+            log::info!(
+                "{type_str} worker {thread_id} cancelled (stale): {hash_count} hashes in {:.2}s ({})",
+                search_elapsed.as_secs_f64(),
+                format_hashrate(hash_rate)
+            );
             let _ = result_tx.try_send(WorkerResult {
                 thread_id,
                 engine_type,
@@ -370,11 +368,25 @@ fn worker_loop(
                 (Some(MiningCandidate { nonce, work, hash }), hash_count)
             }
             engine_cpu::EngineStatus::Exhausted { hash_count } => {
-                log::debug!("{type_str} worker {thread_id} exhausted range ({hash_count} hashes)");
+                let hash_rate = hash_count as f64 / search_elapsed.as_secs_f64();
+                log::info!(
+                    "{type_str} worker {thread_id} exhausted range: {hash_count} hashes in {:.2}s ({})",
+                    search_elapsed.as_secs_f64(),
+                    format_hashrate(hash_rate)
+                );
                 (None, hash_count)
             }
             engine_cpu::EngineStatus::Cancelled { hash_count } => {
-                log::debug!("{type_str} worker {thread_id} cancelled ({hash_count} hashes)");
+                let hash_rate = if search_elapsed.as_secs_f64() > 0.0 {
+                    hash_count as f64 / search_elapsed.as_secs_f64()
+                } else {
+                    0.0
+                };
+                log::info!(
+                    "{type_str} worker {thread_id} cancelled: {hash_count} hashes in {:.2}s ({})",
+                    search_elapsed.as_secs_f64(),
+                    format_hashrate(hash_rate)
+                );
                 (None, hash_count)
             }
             engine_cpu::EngineStatus::Running { .. } => {
@@ -405,7 +417,7 @@ fn worker_loop(
 /// Resolve GPU configuration and initialize the engine.
 pub fn resolve_gpu_configuration(
     requested_devices: Option<usize>,
-    batch_size: Option<u64>,
+    batch_size: u64,
 ) -> anyhow::Result<(Option<Arc<dyn MinerEngine>>, usize)> {
     // Explicit 0 means no GPU
     if requested_devices == Some(0) {
@@ -413,7 +425,7 @@ pub fn resolve_gpu_configuration(
     }
 
     // Try to initialize GPU engine
-    let engine = engine_gpu::GpuEngine::try_with_batch_size(batch_size);
+    let engine = engine_gpu::GpuEngine::try_new(batch_size);
     let engine = match engine {
         Ok(e) => e,
         Err(e) => {
@@ -477,7 +489,7 @@ pub async fn run(config: ServiceConfig) -> anyhow::Result<()> {
 
     // Create CPU engine
     let cpu_engine: Option<Arc<dyn MinerEngine>> = if cpu_workers > 0 {
-        Some(Arc::new(engine_cpu::FastCpuEngine::new()))
+        Some(Arc::new(engine_cpu::FastCpuEngine::new(config.cpu_batch_size)))
     } else {
         None
     };

--- a/crates/miner-service/src/lib.rs
+++ b/crates/miner-service/src/lib.rs
@@ -11,10 +11,10 @@
 pub mod quic;
 
 use crossbeam_channel::{bounded, unbounded, Receiver, Sender};
-use engine_cpu::{EngineCandidate, EngineRange, MinerEngine};
+use engine_cpu::{EngineCandidate, EngineRange, JobIdCancelCheck, MinerEngine};
 use pow_core::format_u512;
 use primitive_types::U512;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::thread;
 
@@ -27,8 +27,8 @@ pub struct ServiceConfig {
     pub cpu_workers: Option<usize>,
     /// Number of GPU devices to use for mining (None = auto-detect)
     pub gpu_devices: Option<usize>,
-    /// GPU cancel check interval in nonces (None = use default of 100,000)
-    pub gpu_cancel_interval: Option<u32>,
+    /// GPU batch size in nonces (None = use default of 10,000,000)
+    pub gpu_batch_size: Option<u64>,
 }
 
 /// Engine type for tracking metrics per compute type.
@@ -44,7 +44,7 @@ impl Default for ServiceConfig {
             node_addr: "127.0.0.1:9833".parse().unwrap(),
             cpu_workers: None,
             gpu_devices: None,
-            gpu_cancel_interval: None,
+            gpu_batch_size: None,
         }
     }
 }
@@ -102,8 +102,6 @@ pub struct WorkerPool {
     job_senders: Vec<Sender<MiningJob>>,
     /// Receiver for collecting results from all workers
     result_rx: Receiver<WorkerResult>,
-    /// Shared cancellation flag for all workers
-    cancel_flag: Arc<AtomicBool>,
     /// Job ID counter - incremented on each new job to detect stale results
     current_job_id: Arc<AtomicU64>,
     /// Thread handles (for cleanup)
@@ -124,7 +122,6 @@ impl WorkerPool {
     ) -> Self {
         let total_workers = cpu_workers + gpu_devices;
         let (result_tx, result_rx) = bounded(total_workers * 64);
-        let cancel_flag = Arc::new(AtomicBool::new(false));
         let current_job_id = Arc::new(AtomicU64::new(0));
 
         let mut job_senders = Vec::with_capacity(total_workers);
@@ -146,7 +143,6 @@ impl WorkerPool {
 
                     let eng = engine.clone();
                     let tx = result_tx.clone();
-                    let cancel = cancel_flag.clone();
                     let job_id_counter = current_job_id.clone();
                     let tid = thread_id;
 
@@ -157,7 +153,6 @@ impl WorkerPool {
                             eng,
                             job_rx,
                             tx,
-                            cancel,
                             job_id_counter,
                         );
                     });
@@ -176,7 +171,6 @@ impl WorkerPool {
 
                     let eng = engine.clone();
                     let tx = result_tx.clone();
-                    let cancel = cancel_flag.clone();
                     let job_id_counter = current_job_id.clone();
                     let tid = thread_id;
 
@@ -187,7 +181,6 @@ impl WorkerPool {
                             eng,
                             job_rx,
                             tx,
-                            cancel,
                             job_id_counter,
                         );
                     });
@@ -200,7 +193,6 @@ impl WorkerPool {
         Self {
             job_senders,
             result_rx,
-            cancel_flag,
             current_job_id,
             _handles: handles,
             cpu_worker_count: cpu_workers,
@@ -216,16 +208,7 @@ impl WorkerPool {
         // will be detected as stale when workers check the job ID before sending results
         let new_job_id = self.current_job_id.fetch_add(1, Ordering::SeqCst) + 1;
 
-        log::debug!("[JOB DISPATCH] Starting job {} - setting cancel flag", new_job_id);
-
-        // Cancel any running job
-        self.cancel_flag.store(true, Ordering::SeqCst);
-
-        // Brief pause to let workers see the cancellation
-        std::thread::sleep(std::time::Duration::from_millis(1));
-
-        // Reset cancel flag for new job
-        self.cancel_flag.store(false, Ordering::SeqCst);
+        log::debug!("[JOB DISPATCH] Starting job {new_job_id}");
 
         // Create job context (shared across all workers)
         let ctx = pow_core::JobContext::new(header_hash, difficulty);
@@ -249,19 +232,15 @@ impl WorkerPool {
         new_job_id
     }
 
-    /// Cancel the current job.
+    /// Cancel the current job by incrementing the job ID.
+    /// Workers will detect the change and stop processing.
     pub fn cancel(&self) {
-        self.cancel_flag.store(true, Ordering::SeqCst);
+        self.current_job_id.fetch_add(1, Ordering::SeqCst);
     }
 
     /// Get the result receiver for collecting worker results.
     pub fn result_receiver(&self) -> &Receiver<WorkerResult> {
         &self.result_rx
-    }
-
-    /// Get the shared cancel flag.
-    pub fn cancel_flag(&self) -> &Arc<AtomicBool> {
-        &self.cancel_flag
     }
 
     /// Total number of workers.
@@ -287,7 +266,6 @@ fn worker_loop(
     engine: Arc<dyn MinerEngine>,
     job_rx: Receiver<MiningJob>,
     result_tx: Sender<WorkerResult>,
-    cancel_flag: Arc<AtomicBool>,
     current_job_id: Arc<AtomicU64>,
 ) {
     let type_str = match engine_type {
@@ -325,22 +303,20 @@ fn worker_loop(
         let job_id = job.job_id;
         log::debug!("[WORKER {type_str}-{thread_id}] Received job {job_id}");
 
-        // Check if already cancelled before starting
-        if cancel_flag.load(Ordering::Relaxed) {
-            log::debug!("[WORKER {type_str}-{thread_id}] Job {job_id} already cancelled, skipping");
-            continue;
-        }
-
         // Generate random starting nonce for this job
         let start = generate_random_nonce();
         let end = U512::MAX;
 
         log::debug!("[WORKER {type_str}-{thread_id}] Starting search for job {job_id}");
 
-        // Execute the search
+        // Execute the search - both CPU and GPU use job ID comparison for cancellation
         let search_start = std::time::Instant::now();
         let range = EngineRange { start, end };
-        let result = engine.search_range(&job.ctx, range, &cancel_flag);
+        let cancel_check = JobIdCancelCheck {
+            current_job_id: &current_job_id,
+            my_job_id: job_id,
+        };
+        let result = engine.search_range(&job.ctx, range, &cancel_check);
         let search_elapsed = search_start.elapsed();
         
         let result_type = match &result {
@@ -429,7 +405,7 @@ fn worker_loop(
 /// Resolve GPU configuration and initialize the engine.
 pub fn resolve_gpu_configuration(
     requested_devices: Option<usize>,
-    cancel_interval: Option<u32>,
+    batch_size: Option<u64>,
 ) -> anyhow::Result<(Option<Arc<dyn MinerEngine>>, usize)> {
     // Explicit 0 means no GPU
     if requested_devices == Some(0) {
@@ -437,10 +413,7 @@ pub fn resolve_gpu_configuration(
     }
 
     // Try to initialize GPU engine
-    let engine = match cancel_interval {
-        Some(interval) => engine_gpu::GpuEngine::try_with_cancel_interval(interval),
-        None => engine_gpu::GpuEngine::try_new(),
-    };
+    let engine = engine_gpu::GpuEngine::try_with_batch_size(batch_size);
     let engine = match engine {
         Ok(e) => e,
         Err(e) => {
@@ -481,8 +454,10 @@ pub async fn run(config: ServiceConfig) -> anyhow::Result<()> {
     let effective_cpus = num_cpus::get().max(1);
 
     // Resolve GPU configuration
-    let (gpu_engine, gpu_devices) =
-        resolve_gpu_configuration(config.gpu_devices, config.gpu_cancel_interval)?;
+    let (gpu_engine, gpu_devices) = resolve_gpu_configuration(
+        config.gpu_devices,
+        config.gpu_batch_size,
+    )?;
 
     // Resolve CPU workers
     let cpu_workers = config.cpu_workers.unwrap_or_else(|| {

--- a/crates/miner-service/src/lib.rs
+++ b/crates/miner-service/src/lib.rs
@@ -10,7 +10,7 @@
 
 pub mod quic;
 
-use crossbeam_channel::{bounded, Receiver, Sender};
+use crossbeam_channel::{bounded, unbounded, Receiver, Sender};
 use engine_cpu::{EngineCandidate, EngineRange, MinerEngine};
 use pow_core::format_u512;
 use primitive_types::U512;
@@ -141,7 +141,7 @@ impl WorkerPool {
         if cpu_workers > 0 {
             if let Some(ref engine) = cpu_engine {
                 for _ in 0..cpu_workers {
-                    let (job_tx, job_rx) = bounded::<MiningJob>(1);
+                    let (job_tx, job_rx) = unbounded::<MiningJob>();
                     job_senders.push(job_tx);
 
                     let eng = engine.clone();
@@ -171,7 +171,7 @@ impl WorkerPool {
         if gpu_devices > 0 {
             if let Some(ref engine) = gpu_engine {
                 for _ in 0..gpu_devices {
-                    let (job_tx, job_rx) = bounded::<MiningJob>(1);
+                    let (job_tx, job_rx) = unbounded::<MiningJob>();
                     job_senders.push(job_tx);
 
                     let eng = engine.clone();
@@ -216,6 +216,8 @@ impl WorkerPool {
         // will be detected as stale when workers check the job ID before sending results
         let new_job_id = self.current_job_id.fetch_add(1, Ordering::SeqCst) + 1;
 
+        log::debug!("[JOB DISPATCH] Starting job {} - setting cancel flag", new_job_id);
+
         // Cancel any running job
         self.cancel_flag.store(true, Ordering::SeqCst);
 
@@ -232,17 +234,16 @@ impl WorkerPool {
             job_id: new_job_id,
         };
 
-        // Dispatch job to all workers
+        // Dispatch job to all workers (unbounded channels - always succeeds unless worker died)
         for tx in &self.job_senders {
-            // Non-blocking send - if worker is still processing old job, it will
-            // see the cancel flag and exit soon
-            let _ = tx.try_send(job.clone());
+            // Send will only fail if receiver is dropped (worker thread died)
+            let _ = tx.send(job.clone());
         }
 
         log::debug!(
-            "Job dispatched to {} workers (job_id {})",
-            self.job_senders.len(),
-            new_job_id
+            "[JOB DISPATCH] Job {} dispatched to {} workers",
+            new_job_id,
+            self.job_senders.len()
         );
 
         new_job_id
@@ -298,8 +299,10 @@ fn worker_loop(
 
     // Main job processing loop
     loop {
-        // Wait for a job
-        let job = match job_rx.recv() {
+        log::debug!("[WORKER {type_str}-{thread_id}] Waiting for job...");
+        
+        // Wait for a job (blocking)
+        let mut job = match job_rx.recv() {
             Ok(job) => job,
             Err(_) => {
                 // Channel closed, pool is shutting down
@@ -308,12 +311,23 @@ fn worker_loop(
             }
         };
 
+        // Drain channel to get the latest job (in case multiple jobs queued while we were busy)
+        let mut skipped = 0;
+        while let Ok(newer_job) = job_rx.try_recv() {
+            skipped += 1;
+            job = newer_job;
+        }
+        if skipped > 0 {
+            log::debug!("[WORKER {type_str}-{thread_id}] Drained {skipped} stale jobs from queue");
+        }
+
         // Capture the job's ID for later validation
         let job_id = job.job_id;
+        log::debug!("[WORKER {type_str}-{thread_id}] Received job {job_id}");
 
         // Check if already cancelled before starting
         if cancel_flag.load(Ordering::Relaxed) {
-            log::debug!("{type_str} worker {thread_id} skipping cancelled job");
+            log::debug!("[WORKER {type_str}-{thread_id}] Job {job_id} already cancelled, skipping");
             continue;
         }
 
@@ -321,15 +335,25 @@ fn worker_loop(
         let start = generate_random_nonce();
         let end = U512::MAX;
 
-        log::debug!(
-            "{type_str} worker {thread_id} processing job {job_id}: range {} to {}",
-            format_u512(start),
-            format_u512(end)
-        );
+        log::debug!("[WORKER {type_str}-{thread_id}] Starting search for job {job_id}");
 
         // Execute the search
+        let search_start = std::time::Instant::now();
         let range = EngineRange { start, end };
         let result = engine.search_range(&job.ctx, range, &cancel_flag);
+        let search_elapsed = search_start.elapsed();
+        
+        let result_type = match &result {
+            engine_cpu::EngineStatus::Found { .. } => "FOUND",
+            engine_cpu::EngineStatus::Exhausted { .. } => "EXHAUSTED",
+            engine_cpu::EngineStatus::Cancelled { .. } => "CANCELLED",
+            engine_cpu::EngineStatus::Running { .. } => "RUNNING",
+        };
+        log::debug!(
+            "[WORKER {type_str}-{thread_id}] Job {job_id} search finished: {} in {:.2}s",
+            result_type,
+            search_elapsed.as_secs_f64()
+        );
 
         // Check if job ID changed during search - if so, this result is stale
         let actual_job_id = current_job_id.load(Ordering::SeqCst);

--- a/crates/miner-service/src/lib.rs
+++ b/crates/miner-service/src/lib.rs
@@ -27,7 +27,7 @@ pub struct ServiceConfig {
     pub cpu_workers: Option<usize>,
     /// Number of GPU devices to use for mining (None = auto-detect)
     pub gpu_devices: Option<usize>,
-    /// GPU cancel check interval in nonces (None = use default of 10,000)
+    /// GPU cancel check interval in nonces (None = use default of 100,000)
     pub gpu_cancel_interval: Option<u32>,
 }
 

--- a/crates/miner-service/src/lib.rs
+++ b/crates/miner-service/src/lib.rs
@@ -138,14 +138,7 @@ impl WorkerPool {
                     let tid = thread_id;
 
                     let handle = thread::spawn(move || {
-                        worker_loop(
-                            tid,
-                            EngineType::Cpu,
-                            eng,
-                            job_rx,
-                            tx,
-                            job_id_counter,
-                        );
+                        worker_loop(tid, EngineType::Cpu, eng, job_rx, tx, job_id_counter);
                     });
                     handles.push(handle);
                     thread_id += 1;
@@ -166,14 +159,7 @@ impl WorkerPool {
                     let tid = thread_id;
 
                     let handle = thread::spawn(move || {
-                        worker_loop(
-                            tid,
-                            EngineType::Gpu,
-                            eng,
-                            job_rx,
-                            tx,
-                            job_id_counter,
-                        );
+                        worker_loop(tid, EngineType::Gpu, eng, job_rx, tx, job_id_counter);
                     });
                     handles.push(handle);
                     thread_id += 1;
@@ -269,7 +255,7 @@ fn worker_loop(
     // Main job processing loop
     loop {
         log::debug!("[WORKER {type_str}-{thread_id}] Waiting for job...");
-        
+
         // Wait for a job (blocking)
         let mut job = match job_rx.recv() {
             Ok(job) => job,
@@ -309,7 +295,7 @@ fn worker_loop(
         };
         let result = engine.search_range(&job.ctx, range, &cancel_check);
         let search_elapsed = search_start.elapsed();
-        
+
         let result_type = match &result {
             engine_cpu::EngineStatus::Found { .. } => "FOUND",
             engine_cpu::EngineStatus::Exhausted { .. } => "EXHAUSTED",
@@ -466,10 +452,8 @@ pub async fn run(config: ServiceConfig) -> anyhow::Result<()> {
     let effective_cpus = num_cpus::get().max(1);
 
     // Resolve GPU configuration
-    let (gpu_engine, gpu_devices) = resolve_gpu_configuration(
-        config.gpu_devices,
-        config.gpu_batch_size,
-    )?;
+    let (gpu_engine, gpu_devices) =
+        resolve_gpu_configuration(config.gpu_devices, config.gpu_batch_size)?;
 
     // Resolve CPU workers
     let cpu_workers = config.cpu_workers.unwrap_or_else(|| {
@@ -489,7 +473,9 @@ pub async fn run(config: ServiceConfig) -> anyhow::Result<()> {
 
     // Create CPU engine
     let cpu_engine: Option<Arc<dyn MinerEngine>> = if cpu_workers > 0 {
-        Some(Arc::new(engine_cpu::FastCpuEngine::new(config.cpu_batch_size)))
+        Some(Arc::new(engine_cpu::FastCpuEngine::new(
+            config.cpu_batch_size,
+        )))
     } else {
         None
     };

--- a/crates/miner-service/src/quic.rs
+++ b/crates/miner-service/src/quic.rs
@@ -227,9 +227,9 @@ async fn handle_connection(
                 match msg_result {
                     Ok(MinerMessage::NewJob(request)) => {
                         log::info!(
-                            "⛏️ Received job: id={}, hash={}...",
+                            "⛏️ Received job: id={}, hash=0x{}",
                             request.job_id,
-                            &request.mining_hash[..8]
+                            request.mining_hash
                         );
 
                         // Parse header hash


### PR DESCRIPTION
Turns out our cancellation flag strategy was completely broken. GPUs can't check updates to VRAM mid-dispatch. This changes the cancellation strategy to live entirely in rust. It is defined by --cpu-batch-size and --gpu-batch-size CLI args. 

The logs are also improved now.