### PR TITLE
Release v3.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -571,7 +571,7 @@ dependencies = [
 
 [[package]]
 name = "engine-cpu"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "criterion",
  "hex",
@@ -582,7 +582,7 @@ dependencies = [
 
 [[package]]
 name = "engine-gpu"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "bytemuck",
  "criterion",
@@ -1468,7 +1468,7 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "anyhow",
  "log",
@@ -1496,7 +1496,7 @@ dependencies = [
 
 [[package]]
 name = "miner-cli"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "clap",
  "engine-cpu",
@@ -1513,7 +1513,7 @@ dependencies = [
 
 [[package]]
 name = "miner-service"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -1534,7 +1534,7 @@ dependencies = [
 
 [[package]]
 name = "miner-telemetry"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "anyhow",
  "futures",
@@ -2018,7 +2018,7 @@ dependencies = [
 
 [[package]]
 name = "pow-core"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "hex",
  "primitive-types 0.13.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ resolver = "2"
 edition = "2021"
 authors = ["Quantus Network"]
 description = "Quantus External Miner Workspace"
-version = "3.1.0"
+version = "3.2.0"
 
 [workspace.dependencies]
 anyhow = "1"


### PR DESCRIPTION
Automated version bump for release v3.2.0.

## Overview
- Version bump: minor
- Type: minor
- Draft: false

## What changed
- Updated version in Cargo.toml and Cargo.lock

Triggered by workflow run: https://github.com/Quantus-Network/quantus-miner/actions/runs/27391244189

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only metadata change with no logic, dependency, or API modifications.
> 
> **Overview**
> Automated **minor release** bump for the Quantus external miner workspace from **3.1.0** to **3.2.0**.
> 
> `[workspace.package].version` in `Cargo.toml` is updated, and `Cargo.lock` is refreshed so all first-party crates (`engine-cpu`, `engine-gpu`, `metrics`, `miner-cli`, `miner-service`, `miner-telemetry`, `pow-core`) report **3.2.0**. No application or library source changes are included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0012915fe5a28519d283a903896ea5813738e75. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->