### PR TITLE
Select GPU adapters by backend to fix multi-backend duplication and OOM

### DIFF
--- a/crates/engine-gpu/src/lib.rs
+++ b/crates/engine-gpu/src/lib.rs
@@ -138,6 +138,68 @@ impl GpuContext {
     }
 }
 
+/// Rank backends for mining: native compute APIs first.
+fn backend_rank(backend: wgpu::Backend) -> u8 {
+    match backend {
+        wgpu::Backend::Vulkan | wgpu::Backend::Metal => 0,
+        wgpu::Backend::Dx12 => 1,
+        _ => 2,
+    }
+}
+
+/// Select which adapters to mine on, returning indices into `infos` ordered
+/// discrete-first.
+///
+/// wgpu can enumerate the same physical GPU once per backend (Vulkan + DX12 on
+/// Windows) plus CPU-emulated fallbacks such as "Microsoft Basic Render Driver".
+/// Mining on every entry causes VRAM contention and OOM (issue #61), so CPU
+/// adapters are dropped and only the best-ranked backend present is kept.
+/// Within a single backend each physical GPU appears exactly once, so rigs with
+/// multiple identical cards keep every card.
+fn select_adapters(infos: &[wgpu::AdapterInfo]) -> Vec<usize> {
+    let usable: Vec<usize> = (0..infos.len())
+        .filter(|&i| {
+            if infos[i].device_type == wgpu::DeviceType::Cpu {
+                log::info!(
+                    target: "gpu_engine",
+                    "Skipping CPU-emulated adapter: {} ({:?})",
+                    infos[i].name,
+                    infos[i].backend
+                );
+                return false;
+            }
+            true
+        })
+        .collect();
+
+    let Some(best) = usable.iter().map(|&i| backend_rank(infos[i].backend)).min() else {
+        return Vec::new();
+    };
+
+    let mut selected: Vec<usize> = usable
+        .into_iter()
+        .filter(|&i| {
+            if backend_rank(infos[i].backend) != best {
+                log::info!(
+                    target: "gpu_engine",
+                    "Skipping adapter on lower-priority backend: {} ({:?})",
+                    infos[i].name,
+                    infos[i].backend
+                );
+                return false;
+            }
+            true
+        })
+        .collect();
+
+    selected.sort_by_key(|&i| match infos[i].device_type {
+        wgpu::DeviceType::DiscreteGpu => 0,
+        wgpu::DeviceType::IntegratedGpu => 1,
+        _ => 2,
+    });
+    selected
+}
+
 impl GpuEngine {
     /// Try to initialize the GPU engine with the given batch size and throttle (ms between batches).
     ///
@@ -145,7 +207,7 @@ impl GpuEngine {
     ///
     /// Returns an error if:
     /// - `batch_size` is zero (no work would be performed)
-    /// - No suitable GPU adapters are found
+    /// - No usable GPU adapters are found
     pub fn try_new(batch_size: u32, throttle_ms: u64) -> Result<Self, Box<dyn std::error::Error>> {
         if batch_size == 0 {
             return Err("batch_size must be non-zero".into());
@@ -161,21 +223,31 @@ impl GpuEngine {
         });
 
         let adapters = instance.enumerate_adapters(wgpu::Backends::PRIMARY);
+        let infos: Vec<wgpu::AdapterInfo> = adapters.iter().map(|a| a.get_info()).collect();
 
-        // Collect adapters to a vector to check count and iterate with index
-        let adapters: Vec<_> = adapters.into_iter().collect();
-
-        if adapters.is_empty() {
-            log::error!(target: "gpu_engine", "No suitable GPU adapters found.");
-            return Err("No suitable GPU adapters found".into());
+        let selected = select_adapters(&infos);
+        if selected.is_empty() {
+            log::error!(
+                target: "gpu_engine",
+                "No usable GPU adapters found ({} enumerated). Use --gpu-devices 0 to disable GPU mining.",
+                infos.len()
+            );
+            return Err("No usable GPU adapters found".into());
         }
 
+        let mut adapters: Vec<Option<wgpu::Adapter>> = adapters.into_iter().map(Some).collect();
         let mut contexts = Vec::new();
-        let mut adapter_infos = Vec::new();
-        for (i, adapter) in adapters.into_iter().enumerate() {
-            let info = adapter.get_info();
-            log::debug!(target: "gpu_engine", "Adapter {} raw info: {:?}", i, info);
-            adapter_infos.push(info.clone());
+        for (i, idx) in selected.into_iter().enumerate() {
+            let adapter = adapters[idx].take().expect("adapter selected exactly once");
+            let info = &infos[idx];
+            log::info!(
+                target: "gpu_engine",
+                "GPU device {i}: {} ({:?}, {:?})",
+                info.name,
+                info.device_type,
+                info.backend
+            );
+            log::debug!(target: "gpu_engine", "Adapter {i} raw info: {info:?}");
 
             let (device, queue) = adapter
                 .request_device(&wgpu::DeviceDescriptor {
@@ -216,7 +288,7 @@ impl GpuEngine {
             log::debug!(target: "gpu_engine", "Pipeline initialized for adapter {}", i);
 
             // Calculate vendor-specific configuration once during initialization
-            let optimal_workgroups = get_vendor_specific_dispatch(&info, &device);
+            let optimal_workgroups = get_vendor_specific_dispatch(info, &device);
 
             contexts.push(Arc::new(GpuContext {
                 device,
@@ -908,4 +980,104 @@ fn get_vendor_specific_dispatch(adapter_info: &wgpu::AdapterInfo, device: &wgpu:
     }
 
     optimal_workgroups
+}
+
+#[cfg(test)]
+mod adapter_selection_tests {
+    use super::*;
+
+    fn info(
+        name: &str,
+        device_type: wgpu::DeviceType,
+        backend: wgpu::Backend,
+    ) -> wgpu::AdapterInfo {
+        wgpu::AdapterInfo {
+            name: name.into(),
+            vendor: 0,
+            device: 0,
+            device_type,
+            driver: String::new(),
+            driver_info: String::new(),
+            backend,
+        }
+    }
+
+    #[test]
+    fn windows_multi_backend_keeps_one_context_per_physical_gpu() {
+        // The exact enumeration from issue #61
+        let infos = [
+            info(
+                "AMD Radeon(TM) Graphics",
+                wgpu::DeviceType::IntegratedGpu,
+                wgpu::Backend::Vulkan,
+            ),
+            info(
+                "NVIDIA GeForce RTX 3070",
+                wgpu::DeviceType::DiscreteGpu,
+                wgpu::Backend::Vulkan,
+            ),
+            info(
+                "AMD Radeon(TM) Graphics",
+                wgpu::DeviceType::IntegratedGpu,
+                wgpu::Backend::Dx12,
+            ),
+            info(
+                "NVIDIA GeForce RTX 3070",
+                wgpu::DeviceType::DiscreteGpu,
+                wgpu::Backend::Dx12,
+            ),
+            info(
+                "Microsoft Basic Render Driver",
+                wgpu::DeviceType::Cpu,
+                wgpu::Backend::Dx12,
+            ),
+        ];
+        assert_eq!(select_adapters(&infos), vec![1, 0]);
+    }
+
+    #[test]
+    fn identical_multi_gpu_rig_keeps_every_card() {
+        let infos = [
+            info(
+                "RTX 3090",
+                wgpu::DeviceType::DiscreteGpu,
+                wgpu::Backend::Vulkan,
+            ),
+            info(
+                "RTX 3090",
+                wgpu::DeviceType::DiscreteGpu,
+                wgpu::Backend::Vulkan,
+            ),
+            info(
+                "RTX 3090",
+                wgpu::DeviceType::DiscreteGpu,
+                wgpu::Backend::Vulkan,
+            ),
+        ];
+        assert_eq!(select_adapters(&infos), vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn dx12_only_machine_keeps_all_dx12_adapters() {
+        let infos = [
+            info("iGPU", wgpu::DeviceType::IntegratedGpu, wgpu::Backend::Dx12),
+            info("dGPU", wgpu::DeviceType::DiscreteGpu, wgpu::Backend::Dx12),
+        ];
+        assert_eq!(select_adapters(&infos), vec![1, 0]);
+    }
+
+    #[test]
+    fn software_only_environment_selects_nothing() {
+        let infos = [info(
+            "llvmpipe",
+            wgpu::DeviceType::Cpu,
+            wgpu::Backend::Vulkan,
+        )];
+        assert!(select_adapters(&infos).is_empty());
+    }
+
+    #[test]
+    fn empty_enumeration_selects_nothing() {
+        assert!(select_adapters(&[]).is_empty());
+    }
 }


### PR DESCRIPTION
## Overview

Clean reimplementation of the fix attempted in #62, addressing the issues raised in its review. Closes #61.

On Windows, wgpu enumerates each physical GPU once per backend (Vulkan + DX12) plus a CPU-emulated software fallback (`Microsoft Basic Render Driver`). `GpuEngine::init` builds a mining context for every entry, so a hybrid laptop yields 5 contexts competing for the same VRAM and the process OOMs during benchmark/serve startup.

## What changed (engine-gpu only)

Rather than deduplicating adapters by `(vendor, device)` PCI IDs — which collapses rigs with multiple identical cards into one context, including on Linux where no cross-backend duplicates exist — adapter selection works by backend:

1. Drop `DeviceType::Cpu` adapters (software fallbacks are never useful for PoW, and this also filters lavapipe/llvmpipe on Linux).
2. Keep all adapters from the highest-ranked backend present (Vulkan/Metal, then DX12, then others). Within a single backend each physical GPU appears exactly once, so identical cards survive by construction — no physical-ID matching needed, and backends that report `vendor/device = 0` (e.g. Metal) can't cause false merges.
3. Order the selection discrete-first, so `--gpu-devices 1` on a hybrid laptop picks the discrete card instead of the first enumerated iGPU (also raised in #61).

Each skipped adapter is logged at info level, each selected device gets an info log with name/type/backend, and init fails with an explicit error (pointing at `--gpu-devices 0`) if nothing usable remains. The selection logic is a pure index-based function (`select_adapters`) over `AdapterInfo`, unit-tested without GPU hardware. Also removes the dead `adapter_infos` local from `init`.

No public API changes; `try_new` and `device_count()` signatures are untouched.

## Validation

- `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `cargo test --workspace --locked`: all pass, including 5 new unit tests covering the exact #61 enumeration (5 entries → 2 contexts, discrete first), identical multi-GPU rigs (all cards kept), DX12-only machines, software-only environments, and empty enumeration
- Runtime sanity on macOS (Apple M5 Pro / Metal): single context selected, benchmark mines normally

Not validated on multi-GPU Windows hardware — @adamtpang, if you can run your #61 repro on this branch, that would confirm the fix end-to-end (expect 2 contexts: `GPU device 0: NVIDIA ... (DiscreteGpu, Vulkan)`, `GPU device 1: AMD ... (IntegratedGpu, Vulkan)`).

## Risks and mitigations

- A GPU exposed only through a lower-ranked backend (e.g. discrete card with broken Vulkan driver, iGPU with working one) would be skipped. Rare, explicitly logged, and recoverable by fixing the driver; a `--gpu-adapter` selector remains a possible follow-up.
- Setups that intentionally mine on a software adapter now get an init error instead — the CPU engine is the right tool there, and `--gpu-devices 0` silences GPU probing.

## Follow-ups

- #61 also suggests lowering default batch size for integrated GPUs sharing system RAM; out of scope here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which GPUs get mining contexts at startup (behavioral fix on Windows); a GPU only exposed via a lower-ranked backend could be skipped, though that is logged.
> 
> **Overview**
> Fixes **Windows multi-backend enumeration** where wgpu listed the same GPUs on Vulkan and DX12 plus CPU fallbacks, causing **multiple mining contexts per card** and **VRAM OOM** (#61).
> 
> **`select_adapters`** replaces “init every enumerated adapter + skip by name” with: drop **`DeviceType::Cpu`**, keep only adapters on the **highest-priority backend** (Vulkan/Metal, then DX12), and order indices **discrete GPU first** so limited `--gpu-devices` picks the dGPU. Init now builds contexts only for those indices, logs skips at info, and fails with a clearer **no usable adapters** message (hinting `--gpu-devices 0`). **Five unit tests** cover the #61 case, multi-identical-GPU rigs, DX12-only, and software-only setups.
> 
> **miner-service**: adds a 🎯 prefix to the CPU/GPU “found solution” log line only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22251613fa8bd0e236de5a1c414b83fb79ae2544. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->