### PR TITLE
fix: docker build

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -125,7 +125,7 @@ jobs:
           [ -f dockerfile-source/.dockerignore ] && cp dockerfile-source/.dockerignore ./ || true
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,6 @@ WORKDIR /build
 # Copy workspace files
 COPY Cargo.toml Cargo.lock rust-toolchain taplo.toml ./
 COPY crates ./crates
-COPY tests ./tests
 
 # Build the miner-cli in release mode
 RUN cargo build --release -p miner-cli --locked


### PR DESCRIPTION
## Summary
- Remove copy tests
- bump action to v6

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/Docker packaging only; runtime image still builds only `miner-cli` with no change to miner behavior.
> 
> **Overview**
> Fixes the Docker image build by **stopping the builder stage from copying the `tests` tree** into the build context, so `cargo build -p miner-cli` no longer depends on that directory being present in the image.
> 
> The **Docker Image** workflow now uses **`docker/build-push-action@v6`** instead of v5 for build and push to GHCR (multi-arch, GHA cache unchanged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ab69143316e6df608d7e511b5be128691b0ca27. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->