### PR TITLE
feat: make dockerfile use main an option

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -7,6 +7,11 @@ on:
         description: "Optional: Specify a full version (e.g., v0.3.0 or v0.3.1-beta.1) to build. If empty, uses the latest release tag. MUST start with 'v'."
         required: false
         default: ""
+      use_main_dockerfile:
+        description: "Optional: Use the main Dockerfile instead of the tag version-specific Dockerfile. If empty, uses the tag version-specific Dockerfile."
+        required: false
+        default: false 
+        type: boolean
 
 env:
   CARGO_TERM_COLOR: always
@@ -96,19 +101,8 @@ jobs:
         with:
           ref: ${{ env.TARGET_VERSION_WITH_V }}
 
-      - name: Check if Dockerfile exists in tag
-        id: check_dockerfile
-        run: |
-          if [ ! -f Dockerfile ]; then
-            echo "::warning::Dockerfile not found in tag ${{ env.TARGET_VERSION_WITH_V }}, falling back to main branch Dockerfile"
-            echo "use_main=true" >> $GITHUB_OUTPUT
-          else
-            echo "Dockerfile found in tag"
-            echo "use_main=false" >> $GITHUB_OUTPUT
-          fi
-
       - name: Checkout main branch for Dockerfile (if needed)
-        if: steps.check_dockerfile.outputs.use_main == 'true'
+        if: github.event.inputs.use_main_dockerfile == 'true'
         uses: actions/checkout@v4
         with:
           ref: main
@@ -119,7 +113,7 @@ jobs:
           path: dockerfile-source
 
       - name: Copy Dockerfile from main (if needed)
-        if: steps.check_dockerfile.outputs.use_main == 'true'
+        if: github.event.inputs.use_main_dockerfile == 'true'
         run: |
           cp dockerfile-source/Dockerfile ./
           [ -f dockerfile-source/.dockerignore ] && cp dockerfile-source/.dockerignore ./ || true


### PR DESCRIPTION
## Summary
Previously always use the tag Dockerfile, this put in dilemma when the tag dockerfile is buggy even though there is problem with the codebase. 

So, now we can manually choose to use the main branch Dockerfile to be used instead of the default of using tag Dockerfile.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to a manually triggered workflow; default build behavior is unchanged unless the new input is set.
> 
> **Overview**
> The **Docker Image** workflow_dispatch job now accepts **`use_main_dockerfile`** (boolean, default **false**). When enabled, the build still checks out the target release tag for source but overlays **`Dockerfile`** and **`.dockerignore`** from **`main`** before `docker/build-push-action` runs.
> 
> The previous step that **automatically** fell back to **`main`** when the tag had no **`Dockerfile`** is removed. Fallback is **manual only**; otherwise the tag’s **`Dockerfile`** is used as-is.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d53fff54b02b5c9bb7bbecff682b65da7f60946. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->