### PR TITLE
Release v3.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -571,7 +571,7 @@ dependencies = [
 
 [[package]]
 name = "engine-cpu"
-version = "3.2.0"
+version = "3.3.0"
 dependencies = [
  "criterion",
  "hex",
@@ -582,7 +582,7 @@ dependencies = [
 
 [[package]]
 name = "engine-gpu"
-version = "3.2.0"
+version = "3.3.0"
 dependencies = [
  "bytemuck",
  "criterion",
@@ -1470,7 +1470,7 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "3.2.0"
+version = "3.3.0"
 dependencies = [
  "anyhow",
  "log",
@@ -1498,7 +1498,7 @@ dependencies = [
 
 [[package]]
 name = "miner-cli"
-version = "3.2.0"
+version = "3.3.0"
 dependencies = [
  "clap",
  "engine-cpu",
@@ -1515,7 +1515,7 @@ dependencies = [
 
 [[package]]
 name = "miner-service"
-version = "3.2.0"
+version = "3.3.0"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -1536,7 +1536,7 @@ dependencies = [
 
 [[package]]
 name = "miner-telemetry"
-version = "3.2.0"
+version = "3.3.0"
 dependencies = [
  "anyhow",
  "futures",
@@ -2020,7 +2020,7 @@ dependencies = [
 
 [[package]]
 name = "pow-core"
-version = "3.2.0"
+version = "3.3.0"
 dependencies = [
  "hex",
  "primitive-types 0.13.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ resolver = "2"
 edition = "2021"
 authors = ["Quantus Network"]
 description = "Quantus External Miner Workspace"
-version = "3.2.0"
+version = "3.3.0"
 
 [workspace.dependencies]
 anyhow = "1"


### PR DESCRIPTION
Automated version bump for release v3.3.0.

## Overview
- Version bump: minor
- Type: minor
- Draft: false

## What changed
- Updated version in Cargo.toml and Cargo.lock

Triggered by workflow run: https://github.com/Quantus-Network/quantus-miner/actions/runs/28421968333

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only version bump with no logic, API, or dependency changes in the diff.
> 
> **Overview**
> **Release v3.3.0** — automated version bump only.
> 
> The workspace package version in `Cargo.toml` moves from **3.2.0** to **3.3.0**, and `Cargo.lock` is updated so all in-repo crates (`engine-cpu`, `engine-gpu`, `metrics`, `miner-cli`, `miner-service`, `miner-telemetry`, `pow-core`) report **3.3.0**. No source or dependency changes beyond the version fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffb63555e69de2e388a1a3750455365ab1a78e85. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->