### PR TITLE
Release v3.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -571,7 +571,7 @@ dependencies = [
 
 [[package]]
 name = "engine-cpu"
-version = "3.3.0"
+version = "3.3.1"
 dependencies = [
  "criterion",
  "hex",
@@ -582,7 +582,7 @@ dependencies = [
 
 [[package]]
 name = "engine-gpu"
-version = "3.3.0"
+version = "3.3.1"
 dependencies = [
  "bytemuck",
  "criterion",
@@ -1470,7 +1470,7 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "3.3.0"
+version = "3.3.1"
 dependencies = [
  "anyhow",
  "log",
@@ -1498,7 +1498,7 @@ dependencies = [
 
 [[package]]
 name = "miner-cli"
-version = "3.3.0"
+version = "3.3.1"
 dependencies = [
  "clap",
  "engine-cpu",
@@ -1515,7 +1515,7 @@ dependencies = [
 
 [[package]]
 name = "miner-service"
-version = "3.3.0"
+version = "3.3.1"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -1536,7 +1536,7 @@ dependencies = [
 
 [[package]]
 name = "miner-telemetry"
-version = "3.3.0"
+version = "3.3.1"
 dependencies = [
  "anyhow",
  "futures",
@@ -2020,7 +2020,7 @@ dependencies = [
 
 [[package]]
 name = "pow-core"
-version = "3.3.0"
+version = "3.3.1"
 dependencies = [
  "hex",
  "primitive-types 0.13.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ resolver = "2"
 edition = "2021"
 authors = ["Quantus Network"]
 description = "Quantus External Miner Workspace"
-version = "3.3.0"
+version = "3.3.1"
 
 [workspace.dependencies]
 anyhow = "1"


### PR DESCRIPTION
Automated version bump for release v3.3.1.

## Overview
- Version bump: patch
- Type: patch
- Draft: false

## What changed
- Updated version in Cargo.toml and Cargo.lock

Triggered by workflow run: https://github.com/Quantus-Network/quantus-miner/actions/runs/28431071134

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version metadata only; no runtime, security, or behavioral code changes.
> 
> **Overview**
> Automated **patch release** that bumps the workspace from **3.3.0** to **3.3.1**.
> 
> Only `Cargo.toml` (`[workspace.package].version`) and the matching entries in `Cargo.lock` for workspace crates (`engine-cpu`, `engine-gpu`, `metrics`, `miner-cli`, `miner-service`, `miner-telemetry`, `pow-core`) are updated. No application or library source changes are included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6e76769c98b9d96c6650873410806ec067b3dee. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->