### PR TITLE
Add captcha share pool service and browser WASM solver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -378,6 +378,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1529,8 +1535,8 @@ dependencies = [
  "pow-core",
  "primitive-types 0.13.1",
  "quantus-miner-api",
+ "quic-transport",
  "quinn",
- "rustls 0.21.12",
  "tokio",
 ]
 
@@ -2000,15 +2006,16 @@ version = "3.3.1"
 dependencies = [
  "anyhow",
  "clap",
+ "constant_time_eq",
  "env_logger",
  "hex",
  "log",
  "pow-core",
  "primitive-types 0.13.1",
  "quantus-miner-api",
+ "quic-transport",
  "quinn",
  "rand 0.9.2",
- "rustls 0.21.12",
  "serde",
  "serde_json",
  "tokio",
@@ -2271,6 +2278,16 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+]
+
+[[package]]
+name = "quic-transport"
+version = "3.3.1"
+dependencies = [
+ "anyhow",
+ "quantus-miner-api",
+ "quinn",
+ "rustls 0.21.12",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1995,6 +1995,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "pool-service"
+version = "3.3.1"
+dependencies = [
+ "anyhow",
+ "clap",
+ "env_logger",
+ "hex",
+ "log",
+ "pow-core",
+ "primitive-types 0.13.1",
+ "quantus-miner-api",
+ "quinn",
+ "rand 0.9.2",
+ "rustls 0.21.12",
+ "serde",
+ "serde_json",
+ "tokio",
+ "warp",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2806,6 +2827,14 @@ checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "solver-wasm"
+version = "3.3.1"
+dependencies = [
+ "primitive-types 0.13.1",
+ "qpow-math",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
 	"crates/miner-telemetry",
 	"crates/pool-service",
 	"crates/pow-core",
+	"crates/quic-transport",
 	"crates/solver-wasm",
 ]
 default-members = ["crates/miner-cli"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,9 @@ members = [
 	"crates/miner-cli",
 	"crates/miner-service",
 	"crates/miner-telemetry",
+	"crates/pool-service",
 	"crates/pow-core",
+	"crates/solver-wasm",
 ]
 default-members = ["crates/miner-cli"]
 resolver = "2"

--- a/clippy.sh
+++ b/clippy.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Run the same clippy command as CI (see .github/workflows/ci.yml)
+set -euo pipefail
+
+cargo +nightly fmt
+taplo format
+cargo clippy --workspace --all-targets --all-features --locked -- -D warnings

--- a/crates/miner-service/Cargo.toml
+++ b/crates/miner-service/Cargo.toml
@@ -21,7 +21,7 @@ anyhow = { workspace = true }
 
 # QUIC transport
 quinn = "0.10"
-rustls = { version = "0.21", default-features = false, features = ["dangerous_configuration", "quic"] }
+quic-transport = { path = "../quic-transport" }
 getrandom = "0.2"
 
 # Protocol types from the node repo

--- a/crates/miner-service/src/quic.rs
+++ b/crates/miner-service/src/quic.rs
@@ -10,8 +10,6 @@ use std::time::{Duration, Instant};
 
 use engine_cpu::MinerEngine;
 use primitive_types::U512;
-use quinn::{ClientConfig, Endpoint};
-use rustls::client::ServerCertVerified;
 
 use quantus_miner_api::{
     read_message, write_message, ApiResponseStatus, MinerMessage, MiningResult,
@@ -64,38 +62,16 @@ pub async fn connect_and_mine(
     }
 }
 
-/// Establish a QUIC connection to the node.
+/// Establish a QUIC connection to the node (shared transport crate).
 async fn establish_connection(
     addr: SocketAddr,
 ) -> anyhow::Result<(quinn::Connection, quinn::SendStream, quinn::RecvStream)> {
-    let mut crypto = rustls::ClientConfig::builder()
-        .with_safe_defaults()
-        .with_custom_certificate_verifier(Arc::new(InsecureCertVerifier))
-        .with_no_client_auth();
-
-    crypto.alpn_protocols = vec![b"quantus-miner".to_vec()];
-
-    let mut client_config = ClientConfig::new(Arc::new(crypto));
-
-    let mut transport_config = quinn::TransportConfig::default();
-    transport_config.keep_alive_interval(Some(Duration::from_secs(5)));
-    transport_config.max_idle_timeout(Some(Duration::from_secs(15).try_into().unwrap()));
-    client_config.transport_config(Arc::new(transport_config));
-
-    let mut endpoint = Endpoint::client("0.0.0.0:0".parse().unwrap())?;
-    endpoint.set_default_client_config(client_config);
-
-    let connection = endpoint.connect(addr, "localhost")?.await?;
-    log::info!("⛏️ QUIC connection established to {}", addr);
-
-    log::info!("⛏️ Opening bidirectional stream to node...");
-    let (mut send, recv) = connection.open_bi().await?;
-
-    // Send Ready message to establish the stream
-    write_message(&mut send, &MinerMessage::Ready).await?;
-    log::info!("⛏️ Bidirectional stream established");
-
-    Ok((connection, send, recv))
+    let result = quic_transport::connect(addr).await?;
+    log::info!(
+        "⛏️ QUIC connection and bidirectional stream established to {}",
+        addr
+    );
+    Ok(result)
 }
 
 /// Helper to send a message while monitoring connection health.
@@ -320,22 +296,5 @@ async fn handle_connection(
             // Short sleep to yield when no messages
             _ = tokio::time::sleep(Duration::from_millis(1)) => {}
         }
-    }
-}
-
-/// Certificate verifier that accepts any certificate (for self-signed certs).
-struct InsecureCertVerifier;
-
-impl rustls::client::ServerCertVerifier for InsecureCertVerifier {
-    fn verify_server_cert(
-        &self,
-        _end_entity: &rustls::Certificate,
-        _intermediates: &[rustls::Certificate],
-        _server_name: &rustls::ServerName,
-        _scts: &mut dyn Iterator<Item = &[u8]>,
-        _ocsp_response: &[u8],
-        _now: std::time::SystemTime,
-    ) -> Result<ServerCertVerified, rustls::Error> {
-        Ok(ServerCertVerified::assertion())
     }
 }

--- a/crates/pool-service/Cargo.toml
+++ b/crates/pool-service/Cargo.toml
@@ -18,9 +18,12 @@ serde_json = { workspace = true, features = ["std"] }
 tokio = { workspace = true }
 warp = { workspace = true }
 
-# QUIC transport (same versions as miner-service)
+# QUIC transport (shared with miner-service)
 quinn = "0.10"
-rustls = { version = "0.21", default-features = false, features = ["dangerous_configuration", "quic"] }
+quic-transport = { path = "../quic-transport" }
+
+# Constant-time comparison for the site secret
+constant_time_eq = "0.3"
 
 # Protocol types from the node repo
 quantus-miner-api = { workspace = true }

--- a/crates/pool-service/Cargo.toml
+++ b/crates/pool-service/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "pool-service"
+version.workspace = true
+edition.workspace = true
+publish = false
+description = "Captcha share pool: turns browser proof-of-work captcha solves into Quantus mining shares"
+
+[dependencies]
+anyhow = { workspace = true }
+clap = { workspace = true }
+env_logger = { workspace = true }
+hex = { workspace = true }
+log = { workspace = true }
+primitive-types = { workspace = true }
+rand = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true, features = ["std"] }
+tokio = { workspace = true }
+warp = { workspace = true }
+
+# QUIC transport (same versions as miner-service)
+quinn = "0.10"
+rustls = { version = "0.21", default-features = false, features = ["dangerous_configuration", "quic"] }
+
+# Protocol types from the node repo
+quantus-miner-api = { workspace = true }
+
+# Local crates
+pow-core = { path = "../pow-core" }

--- a/crates/pool-service/src/http.rs
+++ b/crates/pool-service/src/http.rs
@@ -1,0 +1,195 @@
+//! HTTP API for the captcha widget (session/share) and for protected sites
+//! (siteverify), plus optional static file serving for the demo page.
+
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use primitive_types::U512;
+use serde::{Deserialize, Serialize};
+use warp::Filter;
+
+use crate::state::{PoolState, ShareOutcome};
+
+#[derive(Serialize)]
+struct SessionResponse {
+    session_id: String,
+    /// Hex, 32 bytes, no 0x prefix.
+    header_hash: String,
+    /// Hex U512, no 0x prefix. Solver iterates nonce_start..nonce_end.
+    nonce_start: String,
+    nonce_end: String,
+    /// Share target as hex U512: a share is valid iff hash < share_target.
+    /// (Target form avoids the solver needing U512 division.)
+    share_target: String,
+    /// Expected number of hashes to find a share (= share difficulty), FYI/UX.
+    expected_hashes: u64,
+    expires_in_secs: u64,
+}
+
+#[derive(Deserialize)]
+struct ShareRequest {
+    session_id: String,
+    /// Hex U512 nonce, no 0x prefix.
+    nonce: String,
+}
+
+#[derive(Serialize)]
+struct ShareResponse {
+    success: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    token: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<&'static str>,
+    block_found: bool,
+}
+
+/// Request shape mirrors reCAPTCHA/Turnstile: `secret` + `response`.
+#[derive(Deserialize)]
+struct SiteVerifyRequest {
+    secret: String,
+    response: String,
+}
+
+#[derive(Serialize)]
+struct SiteVerifyResponse {
+    success: bool,
+    #[serde(rename = "challenge_ts", skip_serializing_if = "Option::is_none")]
+    challenge_ts: Option<u64>,
+    #[serde(rename = "error-codes", skip_serializing_if = "Vec::is_empty")]
+    error_codes: Vec<&'static str>,
+}
+
+pub async fn serve(state: Arc<PoolState>, addr: SocketAddr, serve_dir: Option<PathBuf>) {
+    let with_state = {
+        let state = state.clone();
+        warp::any().map(move || state.clone())
+    };
+
+    // POST /api/session -> new captcha challenge
+    let session = warp::path!("api" / "session")
+        .and(warp::post())
+        .and(with_state.clone())
+        .map(|state: Arc<PoolState>| match state.issue_session() {
+            None => reply_error(warp::http::StatusCode::SERVICE_UNAVAILABLE, "no_job_available"),
+            Some(s) => {
+                let target = U512::MAX / s.share_difficulty;
+                let expected = s.share_difficulty.min(U512::from(u64::MAX)).as_u64();
+                warp::reply::with_status(
+                    warp::reply::json(&SessionResponse {
+                        session_id: s.id,
+                        header_hash: hex::encode(s.job.header),
+                        nonce_start: format!("{:x}", s.nonce_start),
+                        nonce_end: format!("{:x}", s.nonce_end),
+                        share_target: format!("{:x}", target),
+                        expected_hashes: expected,
+                        expires_in_secs: crate::state::SESSION_TTL.as_secs(),
+                    }),
+                    warp::http::StatusCode::OK,
+                )
+            }
+        });
+
+    // POST /api/share -> verify a solved nonce, mint a token
+    let share = warp::path!("api" / "share")
+        .and(warp::post())
+        .and(warp::body::content_length_limit(4096))
+        .and(warp::body::json())
+        .and(with_state.clone())
+        .map(|req: ShareRequest, state: Arc<PoolState>| {
+            let nonce = match U512::from_str_radix(req.nonce.trim_start_matches("0x"), 16) {
+                Ok(n) => n,
+                Err(_) => {
+                    return warp::reply::with_status(
+                        warp::reply::json(&ShareResponse {
+                            success: false,
+                            token: None,
+                            error: Some("malformed_nonce"),
+                            block_found: false,
+                        }),
+                        warp::http::StatusCode::BAD_REQUEST,
+                    )
+                }
+            };
+            match state.submit_share(&req.session_id, nonce) {
+                ShareOutcome::Accepted { token, block_found } => warp::reply::with_status(
+                    warp::reply::json(&ShareResponse {
+                        success: true,
+                        token: Some(token),
+                        error: None,
+                        block_found,
+                    }),
+                    warp::http::StatusCode::OK,
+                ),
+                ShareOutcome::Rejected(reason) => warp::reply::with_status(
+                    warp::reply::json(&ShareResponse {
+                        success: false,
+                        token: None,
+                        error: Some(reason),
+                        block_found: false,
+                    }),
+                    warp::http::StatusCode::FORBIDDEN,
+                ),
+            }
+        });
+
+    // POST /siteverify -> protected site's backend redeems a token
+    let siteverify = warp::path!("siteverify")
+        .and(warp::post())
+        .and(warp::body::content_length_limit(4096))
+        // Accept both JSON and form encoding, like the incumbents do.
+        .and(
+            warp::body::json()
+                .or(warp::body::form())
+                .unify()
+                .map(|req: SiteVerifyRequest| req),
+        )
+        .and(with_state.clone())
+        .map(|req: SiteVerifyRequest, state: Arc<PoolState>| {
+            match state.verify_token(&req.secret, &req.response) {
+                Ok(ts) => warp::reply::json(&SiteVerifyResponse {
+                    success: true,
+                    challenge_ts: Some(ts),
+                    error_codes: vec![],
+                }),
+                Err(code) => warp::reply::json(&SiteVerifyResponse {
+                    success: false,
+                    challenge_ts: None,
+                    error_codes: vec![code],
+                }),
+            }
+        });
+
+    // GET /api/stats -> pool counters
+    let stats = warp::path!("api" / "stats")
+        .and(warp::get())
+        .and(with_state.clone())
+        .map(|state: Arc<PoolState>| warp::reply::json(&state.stats()));
+
+    let cors = warp::cors()
+        .allow_any_origin()
+        .allow_methods(vec!["GET", "POST", "OPTIONS"])
+        .allow_headers(vec!["content-type"]);
+
+    let api = session.or(share).or(siteverify).or(stats);
+
+    log::info!("HTTP API listening on {}", addr);
+    if let Some(dir) = serve_dir {
+        log::info!("Serving demo statics from {}", dir.display());
+        let statics = warp::get().and(warp::fs::dir(dir));
+        warp::serve(api.or(statics).with(cors)).run(addr).await;
+    } else {
+        warp::serve(api.with(cors)).run(addr).await;
+    }
+}
+
+fn reply_error(
+    status: warp::http::StatusCode,
+    error: &'static str,
+) -> warp::reply::WithStatus<warp::reply::Json> {
+    #[derive(Serialize)]
+    struct Err<'a> {
+        error: &'a str,
+    }
+    warp::reply::with_status(warp::reply::json(&Err { error }), status)
+}

--- a/crates/pool-service/src/http.rs
+++ b/crates/pool-service/src/http.rs
@@ -71,11 +71,8 @@ pub async fn serve(state: Arc<PoolState>, addr: SocketAddr, serve_dir: Option<Pa
         .and(warp::post())
         .and(with_state.clone())
         .map(|state: Arc<PoolState>| match state.issue_session() {
-            None => reply_error(
-                warp::http::StatusCode::SERVICE_UNAVAILABLE,
-                "no_job_available",
-            ),
-            Some(s) => {
+            Err(reason) => reply_error(warp::http::StatusCode::SERVICE_UNAVAILABLE, reason),
+            Ok(s) => {
                 let target = U512::MAX / s.share_difficulty;
                 let expected = s.share_difficulty.min(U512::from(u64::MAX)).as_u64();
                 warp::reply::with_status(

--- a/crates/pool-service/src/http.rs
+++ b/crates/pool-service/src/http.rs
@@ -1,7 +1,7 @@
 //! HTTP API for the captcha widget (session/share) and for protected sites
 //! (siteverify), plus optional static file serving for the demo page.
 
-use std::net::SocketAddr;
+use std::net::{IpAddr, SocketAddr};
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -9,6 +9,7 @@ use primitive_types::U512;
 use serde::{Deserialize, Serialize};
 use warp::Filter;
 
+use crate::rate_limit::SessionIssuerLimiter;
 use crate::state::{PoolState, ShareOutcome};
 
 #[derive(Serialize)]
@@ -60,35 +61,56 @@ struct SiteVerifyResponse {
     error_codes: Vec<&'static str>,
 }
 
-pub async fn serve(state: Arc<PoolState>, addr: SocketAddr, serve_dir: Option<PathBuf>) {
+pub async fn serve(
+    state: Arc<PoolState>,
+    limiter: Arc<SessionIssuerLimiter>,
+    addr: SocketAddr,
+    serve_dir: Option<PathBuf>,
+) {
     let with_state = {
         let state = state.clone();
         warp::any().map(move || state.clone())
+    };
+    let with_limiter = {
+        let limiter = limiter.clone();
+        warp::any().map(move || limiter.clone())
     };
 
     // POST /api/session -> new captcha challenge
     let session = warp::path!("api" / "session")
         .and(warp::post())
+        .and(warp::addr::remote())
+        .and(with_limiter.clone())
         .and(with_state.clone())
-        .map(|state: Arc<PoolState>| match state.issue_session() {
-            Err(reason) => reply_error(warp::http::StatusCode::SERVICE_UNAVAILABLE, reason),
-            Ok(s) => {
-                let target = U512::MAX / s.share_difficulty;
-                let expected = s.share_difficulty.min(U512::from(u64::MAX)).as_u64();
-                warp::reply::with_status(
-                    warp::reply::json(&SessionResponse {
-                        session_id: s.id,
-                        header_hash: hex::encode(s.job.header),
-                        nonce_start: format!("{:x}", s.nonce_start),
-                        nonce_end: format!("{:x}", s.nonce_end),
-                        share_target: format!("{:x}", target),
-                        expected_hashes: expected,
-                        expires_in_secs: crate::state::SESSION_TTL.as_secs(),
-                    }),
-                    warp::http::StatusCode::OK,
-                )
-            }
-        });
+        .map(
+            |remote: Option<SocketAddr>, limiter: Arc<SessionIssuerLimiter>, state: Arc<PoolState>| {
+                let ip = remote
+                    .map(|a| a.ip())
+                    .unwrap_or(IpAddr::from([127, 0, 0, 1]));
+                if let Err(reason) = limiter.check(ip) {
+                    return reply_error(warp::http::StatusCode::TOO_MANY_REQUESTS, reason);
+                }
+                match state.issue_session() {
+                    Err(reason) => reply_error(warp::http::StatusCode::SERVICE_UNAVAILABLE, reason),
+                    Ok(s) => {
+                        let target = U512::MAX / s.share_difficulty;
+                        let expected = s.share_difficulty.min(U512::from(u64::MAX)).as_u64();
+                        warp::reply::with_status(
+                            warp::reply::json(&SessionResponse {
+                                session_id: s.id,
+                                header_hash: hex::encode(s.job.header),
+                                nonce_start: format!("{:x}", s.nonce_start),
+                                nonce_end: format!("{:x}", s.nonce_end),
+                                share_target: format!("{:x}", target),
+                                expected_hashes: expected,
+                                expires_in_secs: crate::state::SESSION_TTL.as_secs(),
+                            }),
+                            warp::http::StatusCode::OK,
+                        )
+                    }
+                }
+            },
+        );
 
     // POST /api/share -> verify a solved nonce, mint a token
     let share = warp::path!("api" / "share")

--- a/crates/pool-service/src/http.rs
+++ b/crates/pool-service/src/http.rs
@@ -71,7 +71,10 @@ pub async fn serve(state: Arc<PoolState>, addr: SocketAddr, serve_dir: Option<Pa
         .and(warp::post())
         .and(with_state.clone())
         .map(|state: Arc<PoolState>| match state.issue_session() {
-            None => reply_error(warp::http::StatusCode::SERVICE_UNAVAILABLE, "no_job_available"),
+            None => reply_error(
+                warp::http::StatusCode::SERVICE_UNAVAILABLE,
+                "no_job_available",
+            ),
             Some(s) => {
                 let target = U512::MAX / s.share_difficulty;
                 let expected = s.share_difficulty.min(U512::from(u64::MAX)).as_u64();

--- a/crates/pool-service/src/http.rs
+++ b/crates/pool-service/src/http.rs
@@ -83,7 +83,9 @@ pub async fn serve(
         .and(with_limiter.clone())
         .and(with_state.clone())
         .map(
-            |remote: Option<SocketAddr>, limiter: Arc<SessionIssuerLimiter>, state: Arc<PoolState>| {
+            |remote: Option<SocketAddr>,
+             limiter: Arc<SessionIssuerLimiter>,
+             state: Arc<PoolState>| {
                 let ip = remote
                     .map(|a| a.ip())
                     .unwrap_or(IpAddr::from([127, 0, 0, 1]));

--- a/crates/pool-service/src/main.rs
+++ b/crates/pool-service/src/main.rs
@@ -1,0 +1,99 @@
+//! Quantus captcha share pool.
+//!
+//! Sits between a quantus-node (external miner protocol) and browser captcha
+//! solvers: hands out low-difficulty share challenges over the real block
+//! header, verifies solves, mints single-use tokens for site backends, and
+//! submits any share that happens to meet full network difficulty as a block.
+
+mod http;
+mod state;
+mod upstream;
+
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use clap::Parser;
+use primitive_types::U512;
+
+#[derive(Parser, Debug)]
+#[command(name = "pool-service", about = "Quantus captcha share pool")]
+struct Args {
+    /// HTTP listen address for the captcha/siteverify API.
+    #[arg(long, default_value = "127.0.0.1:8787", env = "POOL_HTTP_ADDR")]
+    http_addr: SocketAddr,
+
+    /// Address of the quantus-node external-miner QUIC endpoint.
+    /// If omitted, runs in standalone mode with synthetic jobs (demo only).
+    #[arg(long, env = "POOL_NODE_ADDR")]
+    node_addr: Option<SocketAddr>,
+
+    /// Share difficulty: expected number of hashes per captcha solve.
+    /// Measured browser WASM rate ≈ 120 kH/s on an M-series laptop, so
+    /// 50000 ≈ 0.4 s desktop / ~2 s phone. Raise for stronger rate limiting.
+    #[arg(long, default_value = "50000", env = "POOL_SHARE_DIFFICULTY")]
+    share_difficulty: u64,
+
+    /// Secret that protected-site backends must present to /siteverify.
+    #[arg(long, default_value = "dev-secret", env = "POOL_SITE_SECRET")]
+    site_secret: String,
+
+    /// Optional directory of static files to serve (demo page / widget).
+    #[arg(long, env = "POOL_SERVE_DIR")]
+    serve_dir: Option<PathBuf>,
+
+    /// Job rotation interval in standalone mode, seconds.
+    #[arg(long, default_value = "20")]
+    standalone_job_secs: u64,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+    let args = Args::parse();
+
+    anyhow::ensure!(args.share_difficulty > 0, "--share-difficulty must be > 0");
+    if args.site_secret == "dev-secret" {
+        log::warn!("Using default site secret; set --site-secret in production");
+    }
+
+    let (solution_tx, solution_rx) = tokio::sync::mpsc::channel(16);
+    let state = state::PoolState::new(
+        U512::from(args.share_difficulty),
+        args.site_secret.clone(),
+        solution_tx,
+    );
+
+    // Periodic cleanup of expired sessions/tokens.
+    {
+        let state = state.clone();
+        tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(Duration::from_secs(30)).await;
+                state.gc();
+            }
+        });
+    }
+
+    // Job source.
+    {
+        let state = state.clone();
+        match args.node_addr {
+            Some(addr) => {
+                log::info!("Upstream: quantus-node at {}", addr);
+                tokio::spawn(upstream::run_node_client(state, addr, solution_rx));
+            }
+            None => {
+                log::warn!("No --node-addr given: running STANDALONE with synthetic jobs");
+                tokio::spawn(upstream::run_standalone(
+                    state,
+                    Duration::from_secs(args.standalone_job_secs),
+                    solution_rx,
+                ));
+            }
+        }
+    }
+
+    http::serve(state, args.http_addr, args.serve_dir).await;
+    Ok(())
+}

--- a/crates/pool-service/src/main.rs
+++ b/crates/pool-service/src/main.rs
@@ -45,6 +45,14 @@ struct Args {
     /// Job rotation interval in standalone mode, seconds.
     #[arg(long, default_value = "20")]
     standalone_job_secs: u64,
+
+    /// Maximum live captcha sessions; /api/session returns 503 when full.
+    #[arg(long, default_value = "100000", env = "POOL_MAX_SESSIONS")]
+    max_sessions: usize,
+
+    /// Maximum live (unredeemed) share tokens; shares are refused when full.
+    #[arg(long, default_value = "100000", env = "POOL_MAX_TOKENS")]
+    max_tokens: usize,
 }
 
 #[tokio::main]
@@ -62,6 +70,10 @@ async fn main() -> anyhow::Result<()> {
         U512::from(args.share_difficulty),
         args.site_secret.clone(),
         solution_tx,
+        state::Limits {
+            max_sessions: args.max_sessions,
+            max_tokens: args.max_tokens,
+        },
     );
 
     // Periodic cleanup of expired sessions/tokens.

--- a/crates/pool-service/src/main.rs
+++ b/crates/pool-service/src/main.rs
@@ -6,15 +6,19 @@
 //! submits any share that happens to meet full network difficulty as a block.
 
 mod http;
+mod rate_limit;
 mod state;
 mod upstream;
 
 use std::net::SocketAddr;
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::time::Duration;
 
 use clap::Parser;
 use primitive_types::U512;
+
+use crate::rate_limit::SessionRateLimit;
 
 #[derive(Parser, Debug)]
 #[command(name = "pool-service", about = "Quantus captcha share pool")]
@@ -53,6 +57,10 @@ struct Args {
     /// Maximum live (unredeemed) share tokens; shares are refused when full.
     #[arg(long, default_value = "100000", env = "POOL_MAX_TOKENS")]
     max_tokens: usize,
+
+    /// Max /api/session issuances per client IP per minute.
+    #[arg(long, default_value = "60", env = "POOL_SESSIONS_PER_IP_PER_MIN")]
+    sessions_per_ip_per_min: u32,
 }
 
 #[tokio::main]
@@ -76,13 +84,20 @@ async fn main() -> anyhow::Result<()> {
         },
     );
 
-    // Periodic cleanup of expired sessions/tokens.
+    let limiter = Arc::new(rate_limit::SessionIssuerLimiter::new(SessionRateLimit {
+        max_per_ip: args.sessions_per_ip_per_min,
+        window: Duration::from_secs(60),
+    }));
+
+    // Periodic cleanup of expired sessions/tokens and stale rate-limit windows.
     {
         let state = state.clone();
+        let limiter = limiter.clone();
         tokio::spawn(async move {
             loop {
                 tokio::time::sleep(Duration::from_secs(30)).await;
                 state.gc();
+                limiter.gc();
             }
         });
     }
@@ -106,6 +121,6 @@ async fn main() -> anyhow::Result<()> {
         }
     }
 
-    http::serve(state, args.http_addr, args.serve_dir).await;
+    http::serve(state, limiter, args.http_addr, args.serve_dir).await;
     Ok(())
 }

--- a/crates/pool-service/src/rate_limit.rs
+++ b/crates/pool-service/src/rate_limit.rs
@@ -67,14 +67,11 @@ impl SessionIssuerLimiter {
     pub fn gc(&self) {
         let cutoff = self.cfg.window * 2;
         let now = Instant::now();
-        self.by_ip
-            .lock()
-            .unwrap()
-            .retain(|_, w| {
-                w.window_start
-                    .map(|t| now.duration_since(t) < cutoff)
-                    .unwrap_or(true)
-            });
+        self.by_ip.lock().unwrap().retain(|_, w| {
+            w.window_start
+                .map(|t| now.duration_since(t) < cutoff)
+                .unwrap_or(true)
+        });
     }
 }
 

--- a/crates/pool-service/src/rate_limit.rs
+++ b/crates/pool-service/src/rate_limit.rs
@@ -1,0 +1,107 @@
+//! Per-client rate limiting for unauthenticated endpoints.
+//!
+//! `/api/session` is free, so a hard map cap alone still lets an attacker
+//! churn entries at the TTL boundary. A per-IP issuance ceiling bounds that
+//! even when the global cap has headroom.
+
+use std::collections::HashMap;
+use std::net::IpAddr;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+#[derive(Debug, Clone, Copy)]
+pub struct SessionRateLimit {
+    /// Max session issuances per IP per window.
+    pub max_per_ip: u32,
+    pub window: Duration,
+}
+
+impl Default for SessionRateLimit {
+    fn default() -> Self {
+        SessionRateLimit {
+            // 60 sessions/min/IP is generous for real users (a page load is
+            // one) but stops a single host from dominating issuance.
+            max_per_ip: 60,
+            window: Duration::from_secs(60),
+        }
+    }
+}
+
+#[derive(Default)]
+struct IpWindow {
+    count: u32,
+    window_start: Option<Instant>,
+}
+
+pub struct SessionIssuerLimiter {
+    cfg: SessionRateLimit,
+    by_ip: Mutex<HashMap<IpAddr, IpWindow>>,
+}
+
+impl SessionIssuerLimiter {
+    pub fn new(cfg: SessionRateLimit) -> Self {
+        SessionIssuerLimiter {
+            cfg,
+            by_ip: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Returns Ok(()) if this IP may issue another session, Err otherwise.
+    pub fn check(&self, ip: IpAddr) -> Result<(), &'static str> {
+        let now = Instant::now();
+        let mut map = self.by_ip.lock().unwrap();
+        let entry = map.entry(ip).or_default();
+        let window_start = entry.window_start.get_or_insert_with(Instant::now);
+        if now.duration_since(*window_start) >= self.cfg.window {
+            *window_start = now;
+            entry.count = 0;
+        }
+        if entry.count >= self.cfg.max_per_ip {
+            return Err("rate_limited");
+        }
+        entry.count += 1;
+        Ok(())
+    }
+
+    /// Drop stale IP windows so the side table doesn't grow forever.
+    pub fn gc(&self) {
+        let cutoff = self.cfg.window * 2;
+        let now = Instant::now();
+        self.by_ip
+            .lock()
+            .unwrap()
+            .retain(|_, w| {
+                w.window_start
+                    .map(|t| now.duration_since(t) < cutoff)
+                    .unwrap_or(true)
+            });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{Ipv4Addr, Ipv6Addr};
+
+    #[test]
+    fn allows_up_to_cap_then_rejects() {
+        let lim = SessionIssuerLimiter::new(SessionRateLimit {
+            max_per_ip: 2,
+            window: Duration::from_secs(60),
+        });
+        let ip = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+        assert!(lim.check(ip).is_ok());
+        assert!(lim.check(ip).is_ok());
+        assert_eq!(lim.check(ip), Err("rate_limited"));
+    }
+
+    #[test]
+    fn ips_are_independent() {
+        let lim = SessionIssuerLimiter::new(SessionRateLimit {
+            max_per_ip: 1,
+            window: Duration::from_secs(60),
+        });
+        assert!(lim.check(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4))).is_ok());
+        assert!(lim.check(IpAddr::V6(Ipv6Addr::LOCALHOST)).is_ok());
+    }
+}

--- a/crates/pool-service/src/state.rs
+++ b/crates/pool-service/src/state.rs
@@ -86,7 +86,10 @@ pub struct FoundBlock {
 
 pub enum ShareOutcome {
     /// Share accepted; token the client can hand to the protected site.
-    Accepted { token: String, block_found: bool },
+    Accepted {
+        token: String,
+        block_found: bool,
+    },
     Rejected(&'static str),
 }
 
@@ -109,7 +112,10 @@ impl PoolState {
         site_secret: String,
         solution_tx: tokio::sync::mpsc::Sender<FoundBlock>,
     ) -> Arc<Self> {
-        assert!(!share_difficulty.is_zero(), "share difficulty must be non-zero");
+        assert!(
+            !share_difficulty.is_zero(),
+            "share difficulty must be non-zero"
+        );
         Arc::new(PoolState {
             current_job: Mutex::new(None),
             sessions: Mutex::new(HashMap::new()),
@@ -291,7 +297,9 @@ impl PoolState {
 mod tests {
     use super::*;
 
-    fn test_state(share_difficulty: u64) -> (Arc<PoolState>, tokio::sync::mpsc::Receiver<FoundBlock>) {
+    fn test_state(
+        share_difficulty: u64,
+    ) -> (Arc<PoolState>, tokio::sync::mpsc::Receiver<FoundBlock>) {
         let (tx, rx) = tokio::sync::mpsc::channel(4);
         let state = PoolState::new(U512::from(share_difficulty), "secret".into(), tx);
         state.set_job(Job {
@@ -306,8 +314,11 @@ mod tests {
     fn solve(session: &Session) -> U512 {
         let mut nonce = session.nonce_start;
         loop {
-            let (ok, _) =
-                pow_core::is_valid_nonce(session.job.header, nonce.to_big_endian(), session.share_difficulty);
+            let (ok, _) = pow_core::is_valid_nonce(
+                session.job.header,
+                nonce.to_big_endian(),
+                session.share_difficulty,
+            );
             if ok {
                 return nonce;
             }
@@ -330,7 +341,10 @@ mod tests {
         };
 
         assert!(state.verify_token("secret", &token).is_ok());
-        assert_eq!(state.verify_token("secret", &token), Err("token_already_consumed"));
+        assert_eq!(
+            state.verify_token("secret", &token),
+            Err("token_already_consumed")
+        );
         assert_eq!(state.verify_token("wrong", &token), Err("invalid_secret"));
     }
 
@@ -343,7 +357,10 @@ mod tests {
         let outside = session.nonce_end;
         match state.submit_share(&session.id, outside) {
             ShareOutcome::Rejected("nonce_out_of_range") => {}
-            other => panic!("expected out-of-range rejection, got {:?}", matches_str(&other)),
+            other => panic!(
+                "expected out-of-range rejection, got {:?}",
+                matches_str(&other)
+            ),
         }
     }
 
@@ -352,7 +369,10 @@ mod tests {
         let (state, _rx) = test_state(1);
         let session = state.issue_session().unwrap();
         let nonce = session.nonce_start;
-        assert!(matches!(state.submit_share(&session.id, nonce), ShareOutcome::Accepted { .. }));
+        assert!(matches!(
+            state.submit_share(&session.id, nonce),
+            ShareOutcome::Accepted { .. }
+        ));
         match state.submit_share(&session.id, nonce) {
             ShareOutcome::Rejected("session_already_solved") => {}
             other => panic!("expected burned session, got {:?}", matches_str(&other)),
@@ -383,7 +403,9 @@ mod tests {
             ShareOutcome::Accepted { block_found, .. } => assert!(block_found),
             ShareOutcome::Rejected(r) => panic!("rejected: {r}"),
         }
-        let block = rx.try_recv().expect("block solution should be queued upstream");
+        let block = rx
+            .try_recv()
+            .expect("block solution should be queued upstream");
         assert_eq!(block.job_id, "1");
         assert_eq!(block.nonce, nonce);
     }

--- a/crates/pool-service/src/state.rs
+++ b/crates/pool-service/src/state.rs
@@ -17,6 +17,25 @@ pub const TOKEN_TTL: Duration = Duration::from_secs(300);
 /// 2^64 nonces is unreachable within a session TTL at browser hash rates.
 pub const SESSION_RANGE_BITS: u32 = 64;
 
+/// Caps on live entries in the in-memory maps. `/api/session` is free and
+/// unauthenticated, so without a ceiling a request flood becomes a memory-DoS
+/// on the anti-abuse service itself. At the ~300 bytes/entry ballpark the
+/// defaults bound each map to tens of MB.
+#[derive(Debug, Clone, Copy)]
+pub struct Limits {
+    pub max_sessions: usize,
+    pub max_tokens: usize,
+}
+
+impl Default for Limits {
+    fn default() -> Self {
+        Limits {
+            max_sessions: 100_000,
+            max_tokens: 100_000,
+        }
+    }
+}
+
 /// The job the pool is currently handing out to captcha sessions.
 #[derive(Debug, Clone)]
 pub struct Job {
@@ -72,7 +91,12 @@ pub struct PoolState {
     /// Difficulty for captcha shares (expected hashes per solve).
     pub share_difficulty: U512,
     /// Site secret checked by /siteverify.
+    ///
+    /// NOTE: single-tenant by design for now. All tokens are interchangeable
+    /// across any backend holding this secret; per-sitekey secrets land with
+    /// the host-registration follow-up.
     pub site_secret: String,
+    limits: Limits,
     /// Sender used to push network-difficulty solutions upstream.
     pub solution_tx: tokio::sync::mpsc::Sender<FoundBlock>,
 }
@@ -111,6 +135,7 @@ impl PoolState {
         share_difficulty: U512,
         site_secret: String,
         solution_tx: tokio::sync::mpsc::Sender<FoundBlock>,
+        limits: Limits,
     ) -> Arc<Self> {
         assert!(
             !share_difficulty.is_zero(),
@@ -124,6 +149,7 @@ impl PoolState {
             range_counter: AtomicU64::new(0),
             share_difficulty,
             site_secret,
+            limits,
             solution_tx,
         })
     }
@@ -145,8 +171,12 @@ impl PoolState {
     }
 
     /// Issue a new captcha session with a disjoint nonce range.
-    pub fn issue_session(&self) -> Option<Session> {
-        let job = self.current_job()?;
+    pub fn issue_session(&self) -> Result<Session, &'static str> {
+        let job = self.current_job().ok_or("no_job_available")?;
+
+        if self.sessions.lock().unwrap().len() >= self.limits.max_sessions {
+            return Err("at_capacity");
+        }
 
         // Carve the next disjoint 2^64-nonce slice. The counter is 64 bits and
         // slices are 2^64 wide, so slices live in the bottom 2^128 of the U512
@@ -170,7 +200,7 @@ impl PoolState {
             .unwrap()
             .insert(session.id.clone(), session.clone());
         self.stats.lock().unwrap().sessions_issued += 1;
-        Some(session)
+        Ok(session)
     }
 
     /// Verify a submitted share and, if valid, mint a single-use token.
@@ -211,7 +241,9 @@ impl PoolState {
 
         // Jackpot check: does this share meet full network difficulty for the
         // job it was issued against? Only submit if that job is still current.
-        let network_target = U512::MAX / session.job.network_difficulty;
+        // Target derivation delegates to pow-core's canonical JobContext.
+        let network_target =
+            pow_core::JobContext::new(session.job.header, session.job.network_difficulty).target;
         let mut block_found = false;
         if hash < network_target {
             let still_current = self
@@ -219,31 +251,50 @@ impl PoolState {
                 .map(|j| j.job_id == session.job.job_id)
                 .unwrap_or(false);
             if still_current {
-                block_found = true;
-                self.stats.lock().unwrap().blocks_found += 1;
                 log::info!(
                     "BLOCK FOUND by captcha share! job={} nonce={:x}",
                     session.job.job_id,
                     nonce
                 );
-                // Best-effort: if the channel is full the block is lost, which
-                // is acceptable for dust-revenue semantics.
-                let _ = self.solution_tx.try_send(FoundBlock {
+                // This is the revenue event: count it and be loud if the
+                // upstream queue can't take it.
+                match self.solution_tx.try_send(FoundBlock {
                     job_id: session.job.job_id.clone(),
                     nonce,
-                });
+                }) {
+                    Ok(()) => {
+                        block_found = true;
+                        self.stats.lock().unwrap().blocks_found += 1;
+                    }
+                    Err(e) => {
+                        log::error!(
+                            "DROPPED block solution for job {}: upstream queue unavailable ({})",
+                            session.job.job_id,
+                            e
+                        );
+                    }
+                }
             }
         }
 
         let token = random_id();
-        self.tokens.lock().unwrap().insert(
-            token.clone(),
-            ShareToken {
-                created_at: Instant::now(),
-                created_unix: unix_now(),
-                consumed: false,
-            },
-        );
+        {
+            let mut tokens = self.tokens.lock().unwrap();
+            // A full token map means someone is farming shares faster than
+            // TTL expiry; refuse rather than grow without bound. The client
+            // paid hashes for this, so make the refusal explicit.
+            if tokens.len() >= self.limits.max_tokens {
+                return self.reject("at_capacity");
+            }
+            tokens.insert(
+                token.clone(),
+                ShareToken {
+                    created_at: Instant::now(),
+                    created_unix: unix_now(),
+                    consumed: false,
+                },
+            );
+        }
         self.stats.lock().unwrap().shares_accepted += 1;
         ShareOutcome::Accepted { token, block_found }
     }
@@ -251,7 +302,7 @@ impl PoolState {
     /// Redeem a share token (the reCAPTCHA/Turnstile "siteverify" semantics):
     /// valid exactly once, only with the correct site secret.
     pub fn verify_token(&self, secret: &str, token: &str) -> Result<u64, &'static str> {
-        if secret != self.site_secret {
+        if !constant_time_eq::constant_time_eq(secret.as_bytes(), self.site_secret.as_bytes()) {
             return Err("invalid_secret");
         }
         let mut tokens = self.tokens.lock().unwrap();
@@ -301,7 +352,12 @@ mod tests {
         share_difficulty: u64,
     ) -> (Arc<PoolState>, tokio::sync::mpsc::Receiver<FoundBlock>) {
         let (tx, rx) = tokio::sync::mpsc::channel(4);
-        let state = PoolState::new(U512::from(share_difficulty), "secret".into(), tx);
+        let state = PoolState::new(
+            U512::from(share_difficulty),
+            "secret".into(),
+            tx,
+            Limits::default(),
+        );
         state.set_job(Job {
             job_id: "1".into(),
             header: [7u8; 32],
@@ -391,7 +447,7 @@ mod tests {
     fn block_found_signalled_when_share_meets_network_difficulty() {
         let (tx, mut rx) = tokio::sync::mpsc::channel(4);
         // Network difficulty == share difficulty == 2: any valid share is a block.
-        let state = PoolState::new(U512::from(2u64), "secret".into(), tx);
+        let state = PoolState::new(U512::from(2u64), "secret".into(), tx, Limits::default());
         state.set_job(Job {
             job_id: "1".into(),
             header: [9u8; 32],
@@ -408,6 +464,50 @@ mod tests {
             .expect("block solution should be queued upstream");
         assert_eq!(block.job_id, "1");
         assert_eq!(block.nonce, nonce);
+    }
+
+    #[test]
+    fn session_cap_rejects_flood() {
+        let (tx, _rx) = tokio::sync::mpsc::channel(4);
+        let state = PoolState::new(
+            U512::from(1u64),
+            "secret".into(),
+            tx,
+            Limits {
+                max_sessions: 2,
+                max_tokens: 2,
+            },
+        );
+        state.set_job(Job {
+            job_id: "1".into(),
+            header: [7u8; 32],
+            network_difficulty: U512::MAX,
+        });
+        assert!(state.issue_session().is_ok());
+        assert!(state.issue_session().is_ok());
+        assert!(matches!(state.issue_session(), Err("at_capacity")));
+    }
+
+    #[test]
+    fn dropped_block_does_not_count_or_flag() {
+        // Zero-capacity channel: try_send always fails, simulating a stalled
+        // upstream. The share must still be accepted (the user did the work),
+        // but block_found must be false and blocks_found must stay 0.
+        let (tx, rx) = tokio::sync::mpsc::channel(1);
+        drop(rx); // closed channel -> try_send errors
+        let state = PoolState::new(U512::from(2u64), "secret".into(), tx, Limits::default());
+        state.set_job(Job {
+            job_id: "1".into(),
+            header: [9u8; 32],
+            network_difficulty: U512::from(2u64),
+        });
+        let session = state.issue_session().unwrap();
+        let nonce = solve(&session);
+        match state.submit_share(&session.id, nonce) {
+            ShareOutcome::Accepted { block_found, .. } => assert!(!block_found),
+            ShareOutcome::Rejected(r) => panic!("rejected: {r}"),
+        }
+        assert_eq!(state.stats().blocks_found, 0);
     }
 
     fn matches_str(o: &ShareOutcome) -> &'static str {

--- a/crates/pool-service/src/state.rs
+++ b/crates/pool-service/src/state.rs
@@ -1,0 +1,397 @@
+//! Core pool state: the current mining job, captcha sessions with disjoint
+//! nonce ranges, and single-use share tokens.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use primitive_types::U512;
+use rand::RngCore;
+
+/// How long a captcha session stays solvable after issuance.
+pub const SESSION_TTL: Duration = Duration::from_secs(120);
+/// How long a share token stays redeemable via /siteverify.
+pub const TOKEN_TTL: Duration = Duration::from_secs(300);
+/// Each session gets a disjoint slice of the nonce space this many nonces wide.
+/// 2^64 nonces is unreachable within a session TTL at browser hash rates.
+pub const SESSION_RANGE_BITS: u32 = 64;
+
+/// The job the pool is currently handing out to captcha sessions.
+#[derive(Debug, Clone)]
+pub struct Job {
+    /// Job id assigned by the upstream node (or synthesized in standalone mode).
+    pub job_id: String,
+    /// Block header hash to mine over.
+    pub header: [u8; 32],
+    /// Full network difficulty for this job (block found if a share meets it).
+    pub network_difficulty: U512,
+}
+
+/// A captcha session: one issued challenge, bound to a disjoint nonce range.
+#[derive(Debug, Clone)]
+pub struct Session {
+    pub id: String,
+    /// Snapshot of the job at issuance time. Shares are verified against this
+    /// header even if the pool has since moved to a newer job (grace period =
+    /// session TTL); only network-difficulty solutions for the *current* job
+    /// are submitted upstream.
+    pub job: Job,
+    pub nonce_start: U512,
+    pub nonce_end: U512, // exclusive
+    pub share_difficulty: U512,
+    pub issued_at: Instant,
+    pub solved: bool,
+}
+
+/// A verified share, redeemable exactly once by the protected site's backend.
+#[derive(Debug, Clone)]
+pub struct ShareToken {
+    pub created_at: Instant,
+    pub created_unix: u64,
+    pub consumed: bool,
+}
+
+#[derive(Debug, Default, Clone, serde::Serialize)]
+pub struct PoolStats {
+    pub sessions_issued: u64,
+    pub shares_accepted: u64,
+    pub shares_rejected: u64,
+    pub tokens_verified: u64,
+    pub blocks_found: u64,
+}
+
+pub struct PoolState {
+    /// Current job, None until the first job arrives from the job source.
+    current_job: Mutex<Option<Job>>,
+    sessions: Mutex<HashMap<String, Session>>,
+    tokens: Mutex<HashMap<String, ShareToken>>,
+    stats: Mutex<PoolStats>,
+    /// Monotonic counter used to carve disjoint nonce ranges out of U512 space.
+    range_counter: AtomicU64,
+    /// Difficulty for captcha shares (expected hashes per solve).
+    pub share_difficulty: U512,
+    /// Site secret checked by /siteverify.
+    pub site_secret: String,
+    /// Sender used to push network-difficulty solutions upstream.
+    pub solution_tx: tokio::sync::mpsc::Sender<FoundBlock>,
+}
+
+/// A share that met full network difficulty: a real block solution.
+#[derive(Debug, Clone)]
+pub struct FoundBlock {
+    pub job_id: String,
+    pub nonce: U512,
+}
+
+pub enum ShareOutcome {
+    /// Share accepted; token the client can hand to the protected site.
+    Accepted { token: String, block_found: bool },
+    Rejected(&'static str),
+}
+
+fn random_id() -> String {
+    let mut bytes = [0u8; 24];
+    rand::rng().fill_bytes(&mut bytes);
+    hex::encode(bytes)
+}
+
+fn unix_now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+impl PoolState {
+    pub fn new(
+        share_difficulty: U512,
+        site_secret: String,
+        solution_tx: tokio::sync::mpsc::Sender<FoundBlock>,
+    ) -> Arc<Self> {
+        assert!(!share_difficulty.is_zero(), "share difficulty must be non-zero");
+        Arc::new(PoolState {
+            current_job: Mutex::new(None),
+            sessions: Mutex::new(HashMap::new()),
+            tokens: Mutex::new(HashMap::new()),
+            stats: Mutex::new(PoolStats::default()),
+            range_counter: AtomicU64::new(0),
+            share_difficulty,
+            site_secret,
+            solution_tx,
+        })
+    }
+
+    /// Install a new job (from the upstream node or the standalone generator).
+    /// Existing sessions keep their job snapshot and remain solvable until TTL.
+    pub fn set_job(&self, job: Job) {
+        log::info!(
+            "New job {}: header=0x{} network_difficulty={}",
+            job.job_id,
+            hex::encode(job.header),
+            pow_core::format_u512(job.network_difficulty)
+        );
+        *self.current_job.lock().unwrap() = Some(job);
+    }
+
+    pub fn current_job(&self) -> Option<Job> {
+        self.current_job.lock().unwrap().clone()
+    }
+
+    /// Issue a new captcha session with a disjoint nonce range.
+    pub fn issue_session(&self) -> Option<Session> {
+        let job = self.current_job()?;
+
+        // Carve the next disjoint 2^64-nonce slice. The counter is 64 bits and
+        // slices are 2^64 wide, so slices live in the bottom 2^128 of the U512
+        // nonce space and never collide with each other.
+        let index = self.range_counter.fetch_add(1, Ordering::Relaxed);
+        let nonce_start = U512::from(index) << SESSION_RANGE_BITS;
+        let nonce_end = nonce_start + (U512::one() << SESSION_RANGE_BITS);
+
+        let session = Session {
+            id: random_id(),
+            job,
+            nonce_start,
+            nonce_end,
+            share_difficulty: self.share_difficulty,
+            issued_at: Instant::now(),
+            solved: false,
+        };
+
+        self.sessions
+            .lock()
+            .unwrap()
+            .insert(session.id.clone(), session.clone());
+        self.stats.lock().unwrap().sessions_issued += 1;
+        Some(session)
+    }
+
+    /// Verify a submitted share and, if valid, mint a single-use token.
+    pub fn submit_share(&self, session_id: &str, nonce: U512) -> ShareOutcome {
+        let session = {
+            let mut sessions = self.sessions.lock().unwrap();
+            match sessions.get_mut(session_id) {
+                None => return self.reject("unknown_session"),
+                Some(s) => {
+                    if s.solved {
+                        return self.reject("session_already_solved");
+                    }
+                    if s.issued_at.elapsed() > SESSION_TTL {
+                        sessions.remove(session_id);
+                        return self.reject("session_expired");
+                    }
+                    // Mark solved optimistically; unmark on verification failure
+                    // would allow retries, but a failed share means a buggy or
+                    // malicious client, so we burn the session either way.
+                    s.solved = true;
+                    s.clone()
+                }
+            }
+        };
+
+        if nonce < session.nonce_start || nonce >= session.nonce_end {
+            return self.reject("nonce_out_of_range");
+        }
+
+        let (share_valid, hash) = pow_core::is_valid_nonce(
+            session.job.header,
+            nonce.to_big_endian(),
+            session.share_difficulty,
+        );
+        if !share_valid {
+            return self.reject("share_below_target");
+        }
+
+        // Jackpot check: does this share meet full network difficulty for the
+        // job it was issued against? Only submit if that job is still current.
+        let network_target = U512::MAX / session.job.network_difficulty;
+        let mut block_found = false;
+        if hash < network_target {
+            let still_current = self
+                .current_job()
+                .map(|j| j.job_id == session.job.job_id)
+                .unwrap_or(false);
+            if still_current {
+                block_found = true;
+                self.stats.lock().unwrap().blocks_found += 1;
+                log::info!(
+                    "BLOCK FOUND by captcha share! job={} nonce={:x}",
+                    session.job.job_id,
+                    nonce
+                );
+                // Best-effort: if the channel is full the block is lost, which
+                // is acceptable for dust-revenue semantics.
+                let _ = self.solution_tx.try_send(FoundBlock {
+                    job_id: session.job.job_id.clone(),
+                    nonce,
+                });
+            }
+        }
+
+        let token = random_id();
+        self.tokens.lock().unwrap().insert(
+            token.clone(),
+            ShareToken {
+                created_at: Instant::now(),
+                created_unix: unix_now(),
+                consumed: false,
+            },
+        );
+        self.stats.lock().unwrap().shares_accepted += 1;
+        ShareOutcome::Accepted { token, block_found }
+    }
+
+    /// Redeem a share token (the reCAPTCHA/Turnstile "siteverify" semantics):
+    /// valid exactly once, only with the correct site secret.
+    pub fn verify_token(&self, secret: &str, token: &str) -> Result<u64, &'static str> {
+        if secret != self.site_secret {
+            return Err("invalid_secret");
+        }
+        let mut tokens = self.tokens.lock().unwrap();
+        match tokens.get_mut(token) {
+            None => Err("invalid_token"),
+            Some(t) if t.consumed => Err("token_already_consumed"),
+            Some(t) if t.created_at.elapsed() > TOKEN_TTL => {
+                tokens.remove(token);
+                Err("token_expired")
+            }
+            Some(t) => {
+                t.consumed = true;
+                let ts = t.created_unix;
+                self.stats.lock().unwrap().tokens_verified += 1;
+                Ok(ts)
+            }
+        }
+    }
+
+    pub fn stats(&self) -> PoolStats {
+        self.stats.lock().unwrap().clone()
+    }
+
+    /// Drop expired sessions and tokens. Called periodically.
+    pub fn gc(&self) {
+        self.sessions
+            .lock()
+            .unwrap()
+            .retain(|_, s| s.issued_at.elapsed() <= SESSION_TTL);
+        self.tokens
+            .lock()
+            .unwrap()
+            .retain(|_, t| t.created_at.elapsed() <= TOKEN_TTL);
+    }
+
+    fn reject(&self, reason: &'static str) -> ShareOutcome {
+        self.stats.lock().unwrap().shares_rejected += 1;
+        ShareOutcome::Rejected(reason)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_state(share_difficulty: u64) -> (Arc<PoolState>, tokio::sync::mpsc::Receiver<FoundBlock>) {
+        let (tx, rx) = tokio::sync::mpsc::channel(4);
+        let state = PoolState::new(U512::from(share_difficulty), "secret".into(), tx);
+        state.set_job(Job {
+            job_id: "1".into(),
+            header: [7u8; 32],
+            network_difficulty: U512::MAX, // effectively unreachable
+        });
+        (state, rx)
+    }
+
+    /// Brute-force a valid share within the session's range.
+    fn solve(session: &Session) -> U512 {
+        let mut nonce = session.nonce_start;
+        loop {
+            let (ok, _) =
+                pow_core::is_valid_nonce(session.job.header, nonce.to_big_endian(), session.share_difficulty);
+            if ok {
+                return nonce;
+            }
+            nonce += U512::one();
+        }
+    }
+
+    #[test]
+    fn accepts_valid_share_and_verifies_token_once() {
+        let (state, _rx) = test_state(2); // ~2 hashes per solve
+        let session = state.issue_session().unwrap();
+        let nonce = solve(&session);
+
+        let token = match state.submit_share(&session.id, nonce) {
+            ShareOutcome::Accepted { token, block_found } => {
+                assert!(!block_found);
+                token
+            }
+            ShareOutcome::Rejected(r) => panic!("rejected: {r}"),
+        };
+
+        assert!(state.verify_token("secret", &token).is_ok());
+        assert_eq!(state.verify_token("secret", &token), Err("token_already_consumed"));
+        assert_eq!(state.verify_token("wrong", &token), Err("invalid_secret"));
+    }
+
+    #[test]
+    fn rejects_out_of_range_nonce() {
+        let (state, _rx) = test_state(1); // difficulty 1: every nonce is a valid hash
+        let session = state.issue_session().unwrap();
+        // A nonce outside the assigned slice must be rejected even though its
+        // hash trivially meets the share target.
+        let outside = session.nonce_end;
+        match state.submit_share(&session.id, outside) {
+            ShareOutcome::Rejected("nonce_out_of_range") => {}
+            other => panic!("expected out-of-range rejection, got {:?}", matches_str(&other)),
+        }
+    }
+
+    #[test]
+    fn burns_session_after_one_submission() {
+        let (state, _rx) = test_state(1);
+        let session = state.issue_session().unwrap();
+        let nonce = session.nonce_start;
+        assert!(matches!(state.submit_share(&session.id, nonce), ShareOutcome::Accepted { .. }));
+        match state.submit_share(&session.id, nonce) {
+            ShareOutcome::Rejected("session_already_solved") => {}
+            other => panic!("expected burned session, got {:?}", matches_str(&other)),
+        }
+    }
+
+    #[test]
+    fn disjoint_ranges() {
+        let (state, _rx) = test_state(1);
+        let a = state.issue_session().unwrap();
+        let b = state.issue_session().unwrap();
+        assert!(a.nonce_end <= b.nonce_start || b.nonce_end <= a.nonce_start);
+    }
+
+    #[test]
+    fn block_found_signalled_when_share_meets_network_difficulty() {
+        let (tx, mut rx) = tokio::sync::mpsc::channel(4);
+        // Network difficulty == share difficulty == 2: any valid share is a block.
+        let state = PoolState::new(U512::from(2u64), "secret".into(), tx);
+        state.set_job(Job {
+            job_id: "1".into(),
+            header: [9u8; 32],
+            network_difficulty: U512::from(2u64),
+        });
+        let session = state.issue_session().unwrap();
+        let nonce = solve(&session);
+        match state.submit_share(&session.id, nonce) {
+            ShareOutcome::Accepted { block_found, .. } => assert!(block_found),
+            ShareOutcome::Rejected(r) => panic!("rejected: {r}"),
+        }
+        let block = rx.try_recv().expect("block solution should be queued upstream");
+        assert_eq!(block.job_id, "1");
+        assert_eq!(block.nonce, nonce);
+    }
+
+    fn matches_str(o: &ShareOutcome) -> &'static str {
+        match o {
+            ShareOutcome::Accepted { .. } => "accepted",
+            ShareOutcome::Rejected(r) => r,
+        }
+    }
+}

--- a/crates/pool-service/src/upstream.rs
+++ b/crates/pool-service/src/upstream.rs
@@ -25,6 +25,12 @@ pub async fn run_node_client(
     let mut reconnect_delay = Duration::from_secs(1);
     const MAX_RECONNECT_DELAY: Duration = Duration::from_secs(30);
 
+    // A block taken off the channel but not yet acknowledged by a successful
+    // upstream write. Kept across reconnects so a failed write doesn't drop
+    // the block (the node may still accept it after reconnection if the job
+    // hasn't moved on).
+    let mut pending: Option<FoundBlock> = None;
+
     loop {
         log::info!("Connecting to node at {}...", node_addr);
         match establish_connection(node_addr).await {
@@ -33,6 +39,20 @@ pub async fn run_node_client(
                 reconnect_delay = Duration::from_secs(1);
 
                 loop {
+                    // Retry any unsubmitted block before doing anything else.
+                    if let Some(block) = pending.take() {
+                        match submit_block(&mut send, &block).await {
+                            Ok(()) => {
+                                log::info!("Submitted block solution to node (job {})", block.job_id);
+                            }
+                            Err(e) => {
+                                log::error!("Failed to submit block solution, will retry: {}", e);
+                                pending = Some(block);
+                                break; // reconnect and retry
+                            }
+                        }
+                    }
+
                     tokio::select! {
                         biased;
 
@@ -44,20 +64,9 @@ pub async fn run_node_client(
                         // A captcha share met network difficulty: submit it.
                         block = solutions.recv() => {
                             if let Some(block) = block {
-                                let result = MiningResult {
-                                    status: ApiResponseStatus::Completed,
-                                    job_id: block.job_id,
-                                    nonce: Some(format!("{:x}", block.nonce)),
-                                    work: Some(hex::encode(block.nonce.to_big_endian())),
-                                    hash_count: 0,
-                                    elapsed_time: 0.0,
-                                    miner_id: None,
-                                };
-                                if let Err(e) = write_message(&mut send, &MinerMessage::JobResult(result)).await {
-                                    log::error!("Failed to submit block solution: {}", e);
-                                    break;
-                                }
-                                log::info!("Submitted block solution to node");
+                                // Park it in `pending`; the top of the loop
+                                // submits it and keeps it on write failure.
+                                pending = Some(block);
                             }
                         }
 
@@ -90,6 +99,19 @@ pub async fn run_node_client(
         tokio::time::sleep(reconnect_delay).await;
         reconnect_delay = (reconnect_delay * 2).min(MAX_RECONNECT_DELAY);
     }
+}
+
+async fn submit_block(send: &mut quinn::SendStream, block: &FoundBlock) -> std::io::Result<()> {
+    let result = MiningResult {
+        status: ApiResponseStatus::Completed,
+        job_id: block.job_id.clone(),
+        nonce: Some(format!("{:x}", block.nonce)),
+        work: Some(hex::encode(block.nonce.to_big_endian())),
+        hash_count: 0,
+        elapsed_time: 0.0,
+        miner_id: None,
+    };
+    write_message(send, &MinerMessage::JobResult(result)).await
 }
 
 fn parse_job(job_id: &str, mining_hash: &str, difficulty: &str) -> anyhow::Result<Job> {

--- a/crates/pool-service/src/upstream.rs
+++ b/crates/pool-service/src/upstream.rs
@@ -9,8 +9,6 @@ use primitive_types::U512;
 use quantus_miner_api::{
     read_message, write_message, ApiResponseStatus, MinerMessage, MiningResult,
 };
-use quinn::{ClientConfig, Endpoint};
-use rustls::client::ServerCertVerified;
 use tokio::sync::mpsc::Receiver;
 
 use crate::state::{FoundBlock, Job, PoolState};
@@ -33,7 +31,7 @@ pub async fn run_node_client(
 
     loop {
         log::info!("Connecting to node at {}...", node_addr);
-        match establish_connection(node_addr).await {
+        match quic_transport::connect(node_addr).await {
             Ok((connection, mut send, mut recv)) => {
                 log::info!("Connected to node at {}", node_addr);
                 reconnect_delay = Duration::from_secs(1);
@@ -163,46 +161,5 @@ pub async fn run_standalone(
                 }
             }
         }
-    }
-}
-
-async fn establish_connection(
-    addr: SocketAddr,
-) -> anyhow::Result<(quinn::Connection, quinn::SendStream, quinn::RecvStream)> {
-    let mut crypto = rustls::ClientConfig::builder()
-        .with_safe_defaults()
-        .with_custom_certificate_verifier(Arc::new(InsecureCertVerifier))
-        .with_no_client_auth();
-    crypto.alpn_protocols = vec![b"quantus-miner".to_vec()];
-
-    let mut client_config = ClientConfig::new(Arc::new(crypto));
-    let mut transport_config = quinn::TransportConfig::default();
-    transport_config.keep_alive_interval(Some(Duration::from_secs(5)));
-    transport_config.max_idle_timeout(Some(Duration::from_secs(15).try_into().unwrap()));
-    client_config.transport_config(Arc::new(transport_config));
-
-    let mut endpoint = Endpoint::client("0.0.0.0:0".parse().unwrap())?;
-    endpoint.set_default_client_config(client_config);
-
-    let connection = endpoint.connect(addr, "localhost")?.await?;
-    let (mut send, recv) = connection.open_bi().await?;
-    write_message(&mut send, &MinerMessage::Ready).await?;
-    Ok((connection, send, recv))
-}
-
-/// Accepts any certificate (nodes use self-signed certs, same as miner-service).
-struct InsecureCertVerifier;
-
-impl rustls::client::ServerCertVerifier for InsecureCertVerifier {
-    fn verify_server_cert(
-        &self,
-        _end_entity: &rustls::Certificate,
-        _intermediates: &[rustls::Certificate],
-        _server_name: &rustls::ServerName,
-        _scts: &mut dyn Iterator<Item = &[u8]>,
-        _ocsp_response: &[u8],
-        _now: std::time::SystemTime,
-    ) -> Result<ServerCertVerified, rustls::Error> {
-        Ok(ServerCertVerified::assertion())
     }
 }

--- a/crates/pool-service/src/upstream.rs
+++ b/crates/pool-service/src/upstream.rs
@@ -1,0 +1,183 @@
+//! Job sources: either a QUIC connection to a real quantus-node (speaking the
+//! external miner protocol), or a standalone generator for demos/tests.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use primitive_types::U512;
+use quantus_miner_api::{
+    read_message, write_message, ApiResponseStatus, MinerMessage, MiningResult,
+};
+use quinn::{ClientConfig, Endpoint};
+use rustls::client::ServerCertVerified;
+use tokio::sync::mpsc::Receiver;
+
+use crate::state::{FoundBlock, Job, PoolState};
+
+/// Connect to a node as an external miner and keep the pool's job current.
+/// Solutions arriving on `solutions` are pushed upstream as JobResults.
+pub async fn run_node_client(
+    state: Arc<PoolState>,
+    node_addr: SocketAddr,
+    mut solutions: Receiver<FoundBlock>,
+) {
+    let mut reconnect_delay = Duration::from_secs(1);
+    const MAX_RECONNECT_DELAY: Duration = Duration::from_secs(30);
+
+    loop {
+        log::info!("Connecting to node at {}...", node_addr);
+        match establish_connection(node_addr).await {
+            Ok((connection, mut send, mut recv)) => {
+                log::info!("Connected to node at {}", node_addr);
+                reconnect_delay = Duration::from_secs(1);
+
+                loop {
+                    tokio::select! {
+                        biased;
+
+                        reason = connection.closed() => {
+                            log::warn!("Node connection closed: {}", reason);
+                            break;
+                        }
+
+                        // A captcha share met network difficulty: submit it.
+                        block = solutions.recv() => {
+                            if let Some(block) = block {
+                                let result = MiningResult {
+                                    status: ApiResponseStatus::Completed,
+                                    job_id: block.job_id,
+                                    nonce: Some(format!("{:x}", block.nonce)),
+                                    work: Some(hex::encode(block.nonce.to_big_endian())),
+                                    hash_count: 0,
+                                    elapsed_time: 0.0,
+                                    miner_id: None,
+                                };
+                                if let Err(e) = write_message(&mut send, &MinerMessage::JobResult(result)).await {
+                                    log::error!("Failed to submit block solution: {}", e);
+                                    break;
+                                }
+                                log::info!("Submitted block solution to node");
+                            }
+                        }
+
+                        msg = read_message(&mut recv) => {
+                            match msg {
+                                Ok(MinerMessage::NewJob(request)) => {
+                                    match parse_job(&request.job_id, &request.mining_hash, &request.difficulty) {
+                                        Ok(job) => state.set_job(job),
+                                        Err(e) => log::warn!("Ignoring malformed job from node: {}", e),
+                                    }
+                                }
+                                Ok(other) => {
+                                    log::warn!("Unexpected message from node: {:?}", other);
+                                }
+                                Err(e) => {
+                                    log::warn!("Read error from node: {}", e);
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            Err(e) => {
+                log::warn!("Failed to connect to node: {}", e);
+            }
+        }
+
+        log::info!("Reconnecting in {:?}...", reconnect_delay);
+        tokio::time::sleep(reconnect_delay).await;
+        reconnect_delay = (reconnect_delay * 2).min(MAX_RECONNECT_DELAY);
+    }
+}
+
+fn parse_job(job_id: &str, mining_hash: &str, difficulty: &str) -> anyhow::Result<Job> {
+    let bytes = hex::decode(mining_hash)?;
+    let header: [u8; 32] = bytes
+        .try_into()
+        .map_err(|_| anyhow::anyhow!("mining_hash must be 32 bytes"))?;
+    let network_difficulty = U512::from_dec_str(difficulty)
+        .map_err(|e| anyhow::anyhow!("bad difficulty: {:?}", e))?;
+    if network_difficulty.is_zero() {
+        anyhow::bail!("zero difficulty");
+    }
+    Ok(Job {
+        job_id: job_id.to_string(),
+        header,
+        network_difficulty,
+    })
+}
+
+/// Standalone mode: synthesize a fresh random job every `interval` so the
+/// captcha works without a running node. Solutions are logged and dropped.
+pub async fn run_standalone(
+    state: Arc<PoolState>,
+    interval: Duration,
+    mut solutions: Receiver<FoundBlock>,
+) {
+    use rand::RngCore;
+    let mut counter: u64 = 0;
+
+    loop {
+        let mut header = [0u8; 32];
+        rand::rng().fill_bytes(&mut header);
+        counter += 1;
+        state.set_job(Job {
+            job_id: format!("standalone-{}", counter),
+            header,
+            // Unreachable "network" difficulty: standalone mode never finds blocks.
+            network_difficulty: U512::MAX,
+        });
+
+        tokio::select! {
+            _ = tokio::time::sleep(interval) => {}
+            block = solutions.recv() => {
+                if let Some(block) = block {
+                    log::info!("(standalone) would submit block for job {}", block.job_id);
+                }
+            }
+        }
+    }
+}
+
+async fn establish_connection(
+    addr: SocketAddr,
+) -> anyhow::Result<(quinn::Connection, quinn::SendStream, quinn::RecvStream)> {
+    let mut crypto = rustls::ClientConfig::builder()
+        .with_safe_defaults()
+        .with_custom_certificate_verifier(Arc::new(InsecureCertVerifier))
+        .with_no_client_auth();
+    crypto.alpn_protocols = vec![b"quantus-miner".to_vec()];
+
+    let mut client_config = ClientConfig::new(Arc::new(crypto));
+    let mut transport_config = quinn::TransportConfig::default();
+    transport_config.keep_alive_interval(Some(Duration::from_secs(5)));
+    transport_config.max_idle_timeout(Some(Duration::from_secs(15).try_into().unwrap()));
+    client_config.transport_config(Arc::new(transport_config));
+
+    let mut endpoint = Endpoint::client("0.0.0.0:0".parse().unwrap())?;
+    endpoint.set_default_client_config(client_config);
+
+    let connection = endpoint.connect(addr, "localhost")?.await?;
+    let (mut send, recv) = connection.open_bi().await?;
+    write_message(&mut send, &MinerMessage::Ready).await?;
+    Ok((connection, send, recv))
+}
+
+/// Accepts any certificate (nodes use self-signed certs, same as miner-service).
+struct InsecureCertVerifier;
+
+impl rustls::client::ServerCertVerifier for InsecureCertVerifier {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &rustls::Certificate,
+        _intermediates: &[rustls::Certificate],
+        _server_name: &rustls::ServerName,
+        _scts: &mut dyn Iterator<Item = &[u8]>,
+        _ocsp_response: &[u8],
+        _now: std::time::SystemTime,
+    ) -> Result<ServerCertVerified, rustls::Error> {
+        Ok(ServerCertVerified::assertion())
+    }
+}

--- a/crates/pool-service/src/upstream.rs
+++ b/crates/pool-service/src/upstream.rs
@@ -43,7 +43,10 @@ pub async fn run_node_client(
                     if let Some(block) = pending.take() {
                         match submit_block(&mut send, &block).await {
                             Ok(()) => {
-                                log::info!("Submitted block solution to node (job {})", block.job_id);
+                                log::info!(
+                                    "Submitted block solution to node (job {})",
+                                    block.job_id
+                                );
                             }
                             Err(e) => {
                                 log::error!("Failed to submit block solution, will retry: {}", e);

--- a/crates/pool-service/src/upstream.rs
+++ b/crates/pool-service/src/upstream.rs
@@ -97,8 +97,8 @@ fn parse_job(job_id: &str, mining_hash: &str, difficulty: &str) -> anyhow::Resul
     let header: [u8; 32] = bytes
         .try_into()
         .map_err(|_| anyhow::anyhow!("mining_hash must be 32 bytes"))?;
-    let network_difficulty = U512::from_dec_str(difficulty)
-        .map_err(|e| anyhow::anyhow!("bad difficulty: {:?}", e))?;
+    let network_difficulty =
+        U512::from_dec_str(difficulty).map_err(|e| anyhow::anyhow!("bad difficulty: {:?}", e))?;
     if network_difficulty.is_zero() {
         anyhow::bail!("zero difficulty");
     }

--- a/crates/quic-transport/Cargo.toml
+++ b/crates/quic-transport/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "quic-transport"
+version.workspace = true
+edition.workspace = true
+publish = false
+description = "Shared QUIC client transport for connecting to a quantus-node's external-miner endpoint"
+
+[dependencies]
+anyhow = { workspace = true }
+quantus-miner-api = { workspace = true }
+quinn = "0.10"
+rustls = { version = "0.21", default-features = false, features = ["dangerous_configuration", "quic"] }

--- a/crates/quic-transport/src/lib.rs
+++ b/crates/quic-transport/src/lib.rs
@@ -1,0 +1,55 @@
+//! Shared QUIC client used by miner-service and pool-service to connect to a
+//! quantus-node's external-miner endpoint. Nodes use self-signed certificates,
+//! so this transport intentionally skips certificate verification; keeping
+//! that pattern in exactly one place is the point of this crate.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use quantus_miner_api::{write_message, MinerMessage};
+use quinn::{ClientConfig, Endpoint};
+use rustls::client::ServerCertVerified;
+
+/// Establish a QUIC connection to the node's external-miner endpoint, open
+/// the bidirectional stream, and send the initial `Ready` message.
+pub async fn connect(
+    addr: SocketAddr,
+) -> anyhow::Result<(quinn::Connection, quinn::SendStream, quinn::RecvStream)> {
+    let mut crypto = rustls::ClientConfig::builder()
+        .with_safe_defaults()
+        .with_custom_certificate_verifier(Arc::new(InsecureCertVerifier))
+        .with_no_client_auth();
+    crypto.alpn_protocols = vec![b"quantus-miner".to_vec()];
+
+    let mut client_config = ClientConfig::new(Arc::new(crypto));
+    let mut transport_config = quinn::TransportConfig::default();
+    transport_config.keep_alive_interval(Some(Duration::from_secs(5)));
+    transport_config.max_idle_timeout(Some(Duration::from_secs(15).try_into().unwrap()));
+    client_config.transport_config(Arc::new(transport_config));
+
+    let mut endpoint = Endpoint::client("0.0.0.0:0".parse().unwrap())?;
+    endpoint.set_default_client_config(client_config);
+
+    let connection = endpoint.connect(addr, "localhost")?.await?;
+    let (mut send, recv) = connection.open_bi().await?;
+    write_message(&mut send, &MinerMessage::Ready).await?;
+    Ok((connection, send, recv))
+}
+
+/// Accepts any certificate (nodes use self-signed certs).
+struct InsecureCertVerifier;
+
+impl rustls::client::ServerCertVerifier for InsecureCertVerifier {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &rustls::Certificate,
+        _intermediates: &[rustls::Certificate],
+        _server_name: &rustls::ServerName,
+        _scts: &mut dyn Iterator<Item = &[u8]>,
+        _ocsp_response: &[u8],
+        _now: std::time::SystemTime,
+    ) -> Result<ServerCertVerified, rustls::Error> {
+        Ok(ServerCertVerified::assertion())
+    }
+}

--- a/crates/solver-wasm/Cargo.toml
+++ b/crates/solver-wasm/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "solver-wasm"
+version.workspace = true
+edition.workspace = true
+publish = false
+description = "Browser WASM solver for Quantus captcha shares (raw C ABI, no wasm-bindgen)"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+primitive-types = { workspace = true }
+qpow-math = { workspace = true }

--- a/crates/solver-wasm/src/lib.rs
+++ b/crates/solver-wasm/src/lib.rs
@@ -91,7 +91,10 @@ mod tests {
 
         let nonce = U512::from_big_endian(&io[NONCE_OFF..NONCE_OFF + 64]);
         let (valid, hash) = qpow_math::is_valid_nonce(header, nonce.to_big_endian(), difficulty);
-        assert!(valid, "pool-side verification must accept the solver's nonce");
+        assert!(
+            valid,
+            "pool-side verification must accept the solver's nonce"
+        );
         let reported = U512::from_big_endian(&io[HASH_OFF..HASH_OFF + 64]);
         assert_eq!(hash, reported);
     }

--- a/crates/solver-wasm/src/lib.rs
+++ b/crates/solver-wasm/src/lib.rs
@@ -1,0 +1,98 @@
+//! Browser captcha solver: grinds Poseidon2 nonce hashes over a block header.
+//!
+//! Exposed as a raw C-ABI WASM module (no wasm-bindgen) so it can be built
+//! with a bare `cargo build --target wasm32-unknown-unknown` and loaded with
+//! minimal JS glue. All I/O goes through one static buffer:
+//!
+//! ```text
+//! offset   0..32   header hash                     (in)
+//! offset  32..96   nonce, 64-byte big-endian       (in: start; out: found/next)
+//! offset  96..160  share target, 64-byte BE        (in)
+//! offset 160..224  winning hash, 64-byte BE        (out, only when found)
+//! ```
+//!
+//! JS calls `solve(iters)` in chunks (e.g. 5–20k iterations) to keep the
+//! worker responsive; a return of 0 means "keep going" (the nonce field has
+//! been advanced), 1 means the nonce field now holds a valid share.
+
+use primitive_types::U512;
+
+const HEADER_OFF: usize = 0;
+const NONCE_OFF: usize = 32;
+const TARGET_OFF: usize = 96;
+const HASH_OFF: usize = 160;
+const IO_SIZE: usize = 224;
+
+static mut IO: [u8; IO_SIZE] = [0u8; IO_SIZE];
+
+/// Pointer to the shared I/O buffer in WASM linear memory.
+#[no_mangle]
+pub extern "C" fn io_ptr() -> *mut u8 {
+    core::ptr::addr_of_mut!(IO) as *mut u8
+}
+
+/// Size of the shared I/O buffer, for JS-side sanity checks.
+#[no_mangle]
+pub extern "C" fn io_len() -> u32 {
+    IO_SIZE as u32
+}
+
+/// Grind up to `iters` nonces. Returns 1 if a share was found.
+#[no_mangle]
+pub extern "C" fn solve(iters: u32) -> u32 {
+    let io = unsafe { &mut *core::ptr::addr_of_mut!(IO) };
+
+    let mut header = [0u8; 32];
+    header.copy_from_slice(&io[HEADER_OFF..HEADER_OFF + 32]);
+    let mut nonce = U512::from_big_endian(&io[NONCE_OFF..NONCE_OFF + 64]);
+    let target = U512::from_big_endian(&io[TARGET_OFF..TARGET_OFF + 64]);
+
+    for _ in 0..iters {
+        let nonce_bytes = nonce.to_big_endian();
+        let hash = qpow_math::get_nonce_hash(header, nonce_bytes);
+        if hash < target {
+            io[NONCE_OFF..NONCE_OFF + 64].copy_from_slice(&nonce_bytes);
+            io[HASH_OFF..HASH_OFF + 64].copy_from_slice(&hash.to_big_endian());
+            return 1;
+        }
+        nonce = nonce.saturating_add(U512::one());
+    }
+
+    // Not found: persist progress so the next chunk resumes where we stopped.
+    io[NONCE_OFF..NONCE_OFF + 64].copy_from_slice(&nonce.to_big_endian());
+    0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn solve_matches_pool_verification() {
+        // Difficulty 4 -> target = MAX/4; expect a solution within a few iters.
+        let header = [7u8; 32];
+        let difficulty = U512::from(4u64);
+        let target = U512::MAX / difficulty;
+
+        let io = unsafe { &mut *core::ptr::addr_of_mut!(IO) };
+        io[HEADER_OFF..HEADER_OFF + 32].copy_from_slice(&header);
+        let start = U512::from(1u64) << 64; // arbitrary "session range" start
+        io[NONCE_OFF..NONCE_OFF + 64].copy_from_slice(&start.to_big_endian());
+        io[TARGET_OFF..TARGET_OFF + 64].copy_from_slice(&target.to_big_endian());
+
+        let mut found = 0;
+        for _ in 0..64 {
+            found = solve(256);
+            if found == 1 {
+                break;
+            }
+        }
+        assert_eq!(found, 1, "should find a share at difficulty 4");
+
+        let nonce = U512::from_big_endian(&io[NONCE_OFF..NONCE_OFF + 64]);
+        let (valid, hash) = qpow_math::is_valid_nonce(header, nonce.to_big_endian(), difficulty);
+        assert!(valid, "pool-side verification must accept the solver's nonce");
+        let reported = U512::from_big_endian(&io[HASH_OFF..HASH_OFF + 64]);
+        assert_eq!(hash, reported);
+    }
+}


### PR DESCRIPTION
# Summary
New pool-service crate: connects to a node via the external-miner QUIC protocol and turns browser captcha solves into real mining shares — sessions with disjoint nonce ranges over the current header (no precompute/replay/share-theft), single-use tokens, reCAPTCHA-shaped /siteverify, and upstream block submission when a share meets network difficulty. Standalone mode with synthetic jobs for demos.
New solver-wasm crate: raw C-ABI wasm32 build of the Poseidon2 nonce grinder (no wasm-bindgen), ~41 kB, ≈120 kH/s in-browser on an M-series laptop.

Test plan

- 5 unit tests: range enforcement, session burning, token single-use, disjoint ranges, block-found signaling

- Native test proving solver nonces pass pool verification

- Manual e2e: browser solved shares against quantus-node --dev --miner-listen-port 9833, tokens verified, replay rejected

- Payout ledger, metrics, Docker (follow-ups)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New internet-facing HTTP surface (open CORS, default dev site secret) and QUIC client with certificate verification disabled; share/token logic is security-sensitive though largely covered by tests.
> 
> **Overview**
> Adds **`pool-service`** and **`solver-wasm`** to the workspace and wires them in `Cargo.toml` / `Cargo.lock`.
> 
> **`pool-service`** is a new binary that bridges browser captcha PoW and Quantus mining: it pulls jobs from a quantus-node over QUIC (external-miner protocol, same insecure TLS pattern as `miner-service`) or runs **standalone** with rotating synthetic jobs. It exposes a Warp HTTP API (`/api/session`, `/api/share`, `/siteverify`, `/api/stats`, optional static demo files) with permissive CORS. Core state issues sessions with **disjoint 2^64 nonce slices**, verifies shares via `pow_core::is_valid_nonce`, mints **single-use** tokens for reCAPTCHA-style backend verification, and queues **network-difficulty** hits upstream as `JobResult` only when the session job is still current.
> 
> **`solver-wasm`** is a `wasm32` cdylib that grinds nonces with `qpow_math` through a fixed **224-byte C-ABI I/O buffer** (`io_ptr`, `solve(iters)`) so browsers can solve without wasm-bindgen.
> 
> Unit tests cover pool session/token/range/block signaling; `solver-wasm` includes a test that solver output matches pool verification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96871807e1cb838f64083d7dd345c81fe9857125. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->